### PR TITLE
Implement Multi-Chain Event Indexer

### DIFF
--- a/backend/app/indexer/__init__.py
+++ b/backend/app/indexer/__init__.py
@@ -1,0 +1,11 @@
+from .manager import IndexerManager
+from .stellar_indexer import StellarIndexer
+from .bitcoin_indexer import BitcoinIndexer
+from .ethereum_indexer import EthereumIndexer
+
+__all__ = [
+    "IndexerManager",
+    "StellarIndexer",
+    "BitcoinIndexer",
+    "EthereumIndexer",
+]

--- a/backend/app/indexer/base.py
+++ b/backend/app/indexer/base.py
@@ -1,0 +1,127 @@
+"""Base class for chain-specific event indexers."""
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IndexedEvent:
+    """Standardized event representation across all chains."""
+
+    chain: str
+    event_type: str
+    tx_hash: str
+    block_number: int
+    contract_address: str | None
+    data: dict[str, Any]
+    timestamp: datetime | None = None
+
+
+@dataclass
+class IndexerStatus:
+    """Current state of an indexer."""
+
+    chain: str
+    is_running: bool = False
+    last_synced_block: int = 0
+    latest_chain_block: int = 0
+    blocks_behind: int = 0
+    events_processed: int = 0
+    last_error: str | None = None
+    last_sync_at: datetime | None = None
+
+
+class BaseIndexer(ABC):
+    """
+    Abstract base for chain-specific indexers.
+
+    Subclasses implement chain-specific logic for fetching blocks,
+    parsing events, and handling reorgs.
+    """
+
+    def __init__(self, chain: str):
+        self.chain = chain
+        self.status = IndexerStatus(chain=chain)
+        self._running = False
+        self._event_queue: asyncio.Queue[IndexedEvent] = asyncio.Queue()
+
+    @abstractmethod
+    async def get_latest_block(self) -> int:
+        """Get the latest confirmed block number on the chain."""
+
+    @abstractmethod
+    async def fetch_events(
+        self, from_block: int, to_block: int
+    ) -> list[IndexedEvent]:
+        """Fetch events from a block range."""
+
+    @abstractmethod
+    async def handle_reorg(self, reorg_block: int) -> None:
+        """Handle a chain reorganization starting at reorg_block."""
+
+    async def start(self, from_block: int = 0, poll_interval: int = 10) -> None:
+        """Start the indexer loop."""
+        self._running = True
+        self.status.is_running = True
+        self.status.last_synced_block = from_block
+
+        logger.info("[%s] Indexer started from block %d", self.chain, from_block)
+
+        while self._running:
+            try:
+                latest = await self.get_latest_block()
+                self.status.latest_chain_block = latest
+                self.status.blocks_behind = max(
+                    0, latest - self.status.last_synced_block
+                )
+
+                if self.status.last_synced_block < latest:
+                    # Process in batches to avoid overloading
+                    batch_size = min(100, latest - self.status.last_synced_block)
+                    to_block = self.status.last_synced_block + batch_size
+
+                    events = await self.fetch_events(
+                        self.status.last_synced_block + 1, to_block
+                    )
+
+                    for event in events:
+                        await self._event_queue.put(event)
+                        self.status.events_processed += 1
+
+                    self.status.last_synced_block = to_block
+                    self.status.last_sync_at = datetime.utcnow()
+                    self.status.last_error = None
+
+                    if events:
+                        logger.info(
+                            "[%s] Processed %d events (blocks %d-%d)",
+                            self.chain,
+                            len(events),
+                            self.status.last_synced_block - batch_size + 1,
+                            to_block,
+                        )
+
+            except Exception as e:
+                self.status.last_error = str(e)
+                logger.error("[%s] Indexer error: %s", self.chain, e)
+
+            await asyncio.sleep(poll_interval)
+
+    def stop(self) -> None:
+        """Stop the indexer loop."""
+        self._running = False
+        self.status.is_running = False
+        logger.info("[%s] Indexer stopped", self.chain)
+
+    async def get_events(self, max_events: int = 100) -> list[IndexedEvent]:
+        """Drain queued events."""
+        events = []
+        while not self._event_queue.empty() and len(events) < max_events:
+            events.append(self._event_queue.get_nowait())
+        return events

--- a/backend/app/indexer/bitcoin_indexer.py
+++ b/backend/app/indexer/bitcoin_indexer.py
@@ -1,0 +1,101 @@
+"""Bitcoin transaction indexer for cross-chain swap detection."""
+
+import logging
+import os
+from datetime import datetime
+
+import httpx
+
+from .base import BaseIndexer, IndexedEvent
+
+logger = logging.getLogger(__name__)
+
+
+class BitcoinIndexer(BaseIndexer):
+    """Indexes Bitcoin transactions relevant to ChainBridge swaps."""
+
+    def __init__(self):
+        super().__init__(chain="bitcoin")
+        self.rpc_url = os.getenv("BITCOIN_RPC_URL", "http://localhost:18332")
+        self.rpc_user = os.getenv("BITCOIN_RPC_USER", "")
+        self.rpc_password = os.getenv("BITCOIN_RPC_PASSWORD", "")
+        self.confirmations = int(os.getenv("BITCOIN_CONFIRMATIONS", "6"))
+
+    async def _rpc_call(self, method: str, params: list = None) -> dict:
+        """Make a JSON-RPC call to the Bitcoin node."""
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                self.rpc_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": method,
+                    "params": params or [],
+                },
+                auth=(self.rpc_user, self.rpc_password)
+                if self.rpc_user
+                else None,
+                timeout=30,
+            )
+            data = response.json()
+            if "error" in data and data["error"]:
+                raise Exception(f"Bitcoin RPC error: {data['error']}")
+            return data.get("result", {})
+
+    async def get_latest_block(self) -> int:
+        try:
+            count = await self._rpc_call("getblockcount")
+            # Subtract confirmations for safety
+            return max(0, int(count) - self.confirmations)
+        except Exception as e:
+            logger.error("[bitcoin] Failed to get block count: %s", e)
+            raise
+
+    async def fetch_events(
+        self, from_block: int, to_block: int
+    ) -> list[IndexedEvent]:
+        events = []
+        for height in range(from_block, to_block + 1):
+            try:
+                block_hash = await self._rpc_call("getblockhash", [height])
+                block = await self._rpc_call("getblock", [block_hash, 2])
+
+                for tx in block.get("tx", []):
+                    # Look for OP_RETURN outputs containing ChainBridge markers
+                    for vout in tx.get("vout", []):
+                        script = vout.get("scriptPubKey", {})
+                        asm = script.get("asm", "")
+                        if "OP_RETURN" in asm and self._is_bridge_tx(asm):
+                            events.append(
+                                IndexedEvent(
+                                    chain="bitcoin",
+                                    event_type="bridge_deposit",
+                                    tx_hash=tx["txid"],
+                                    block_number=height,
+                                    contract_address=None,
+                                    data={
+                                        "value": vout.get("value", 0),
+                                        "op_return": asm,
+                                    },
+                                    timestamp=datetime.utcfromtimestamp(
+                                        block.get("time", 0)
+                                    ),
+                                )
+                            )
+            except Exception as e:
+                logger.warning("[bitcoin] Error processing block %d: %s", height, e)
+
+        return events
+
+    async def handle_reorg(self, reorg_block: int) -> None:
+        logger.warning(
+            "[bitcoin] Reorg detected at block %d. Rolling back indexed events.",
+            reorg_block,
+        )
+        # In production: delete indexed events >= reorg_block from DB
+        # and re-index from reorg_block
+
+    def _is_bridge_tx(self, asm: str) -> bool:
+        """Check if an OP_RETURN contains a ChainBridge marker."""
+        # ChainBridge transactions use a specific prefix in OP_RETURN
+        return "chainbridge" in asm.lower() or "cb:" in asm.lower()

--- a/backend/app/indexer/ethereum_indexer.py
+++ b/backend/app/indexer/ethereum_indexer.py
@@ -1,0 +1,103 @@
+"""Ethereum event log indexer for cross-chain swap detection."""
+
+import logging
+import os
+from datetime import datetime
+
+import httpx
+
+from .base import BaseIndexer, IndexedEvent
+
+logger = logging.getLogger(__name__)
+
+
+class EthereumIndexer(BaseIndexer):
+    """Indexes Ethereum contract events relevant to ChainBridge swaps."""
+
+    def __init__(self):
+        super().__init__(chain="ethereum")
+        self.rpc_url = os.getenv(
+            "ETHEREUM_RPC_URL", "https://eth-sepolia.g.alchemy.com/v2/demo"
+        )
+        self.contract_address = os.getenv("ETHEREUM_BRIDGE_CONTRACT", "")
+        self.confirmations = int(os.getenv("ETHEREUM_CONFIRMATIONS", "12"))
+
+    async def _rpc_call(self, method: str, params: list = None) -> dict:
+        """Make a JSON-RPC call to the Ethereum node."""
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                self.rpc_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": method,
+                    "params": params or [],
+                },
+                timeout=30,
+            )
+            data = response.json()
+            if "error" in data and data["error"]:
+                raise Exception(f"Ethereum RPC error: {data['error']}")
+            return data.get("result")
+
+    async def get_latest_block(self) -> int:
+        try:
+            result = await self._rpc_call("eth_blockNumber")
+            latest = int(result, 16)
+            return max(0, latest - self.confirmations)
+        except Exception as e:
+            logger.error("[ethereum] Failed to get block number: %s", e)
+            raise
+
+    async def fetch_events(
+        self, from_block: int, to_block: int
+    ) -> list[IndexedEvent]:
+        if not self.contract_address:
+            return []
+
+        events = []
+        try:
+            logs = await self._rpc_call(
+                "eth_getLogs",
+                [
+                    {
+                        "fromBlock": hex(from_block),
+                        "toBlock": hex(to_block),
+                        "address": self.contract_address,
+                    }
+                ],
+            )
+
+            for log in logs or []:
+                try:
+                    block_num = int(log["blockNumber"], 16)
+                    events.append(
+                        IndexedEvent(
+                            chain="ethereum",
+                            event_type=log["topics"][0] if log.get("topics") else "unknown",
+                            tx_hash=log.get("transactionHash", ""),
+                            block_number=block_num,
+                            contract_address=log.get("address"),
+                            data={
+                                "topics": log.get("topics", []),
+                                "data": log.get("data", "0x"),
+                                "log_index": int(log.get("logIndex", "0x0"), 16),
+                            },
+                            timestamp=datetime.utcnow(),
+                        )
+                    )
+                except Exception as e:
+                    logger.warning("[ethereum] Failed to parse log: %s", e)
+
+        except Exception as e:
+            logger.error("[ethereum] Failed to fetch logs: %s", e)
+            raise
+
+        return events
+
+    async def handle_reorg(self, reorg_block: int) -> None:
+        logger.warning(
+            "[ethereum] Reorg detected at block %d. Rolling back indexed events.",
+            reorg_block,
+        )
+        # In production: delete indexed events >= reorg_block from DB

--- a/backend/app/indexer/manager.py
+++ b/backend/app/indexer/manager.py
@@ -1,0 +1,111 @@
+"""
+Multi-chain indexer manager.
+
+Orchestrates multiple chain-specific indexers, manages their lifecycle,
+and provides a unified status API.
+"""
+
+import asyncio
+import logging
+from datetime import datetime
+
+from .base import BaseIndexer, IndexerStatus
+from .stellar_indexer import StellarIndexer
+from .bitcoin_indexer import BitcoinIndexer
+from .ethereum_indexer import EthereumIndexer
+
+logger = logging.getLogger(__name__)
+
+
+class IndexerManager:
+    """
+    Manages all chain indexers and provides unified status monitoring.
+
+    Usage:
+        manager = IndexerManager()
+        await manager.start_all()  # starts indexers as background tasks
+        status = manager.get_all_status()
+        await manager.stop_all()
+    """
+
+    def __init__(self):
+        self.indexers: dict[str, BaseIndexer] = {
+            "stellar": StellarIndexer(),
+            "bitcoin": BitcoinIndexer(),
+            "ethereum": EthereumIndexer(),
+        }
+        self._tasks: dict[str, asyncio.Task] = {}
+
+    async def start_all(
+        self,
+        checkpoints: dict[str, int] | None = None,
+    ) -> None:
+        """Start all indexers from their last checkpoints."""
+        checkpoints = checkpoints or {}
+
+        for chain, indexer in self.indexers.items():
+            from_block = checkpoints.get(chain, 0)
+            task = asyncio.create_task(
+                indexer.start(from_block=from_block),
+                name=f"indexer-{chain}",
+            )
+            self._tasks[chain] = task
+            logger.info("Started %s indexer from block %d", chain, from_block)
+
+    async def stop_all(self) -> None:
+        """Stop all running indexers."""
+        for chain, indexer in self.indexers.items():
+            indexer.stop()
+
+        for chain, task in self._tasks.items():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        self._tasks.clear()
+        logger.info("All indexers stopped")
+
+    def get_all_status(self) -> dict[str, dict]:
+        """Get status of all indexers."""
+        statuses = {}
+        for chain, indexer in self.indexers.items():
+            s = indexer.status
+            statuses[chain] = {
+                "chain": s.chain,
+                "is_running": s.is_running,
+                "last_synced_block": s.last_synced_block,
+                "latest_chain_block": s.latest_chain_block,
+                "blocks_behind": s.blocks_behind,
+                "events_processed": s.events_processed,
+                "last_error": s.last_error,
+                "last_sync_at": s.last_sync_at.isoformat()
+                if s.last_sync_at
+                else None,
+            }
+        return statuses
+
+    def get_status(self, chain: str) -> dict | None:
+        """Get status of a specific chain indexer."""
+        statuses = self.get_all_status()
+        return statuses.get(chain)
+
+    async def catch_up(self, chain: str, from_block: int, to_block: int) -> int:
+        """
+        Sync historical events for a specific chain.
+        Returns the number of events processed.
+        """
+        indexer = self.indexers.get(chain)
+        if not indexer:
+            raise ValueError(f"Unknown chain: {chain}")
+
+        events = await indexer.fetch_events(from_block, to_block)
+        logger.info(
+            "Historical sync for %s: %d events (blocks %d-%d)",
+            chain,
+            len(events),
+            from_block,
+            to_block,
+        )
+        return len(events)

--- a/backend/app/indexer/stellar_indexer.py
+++ b/backend/app/indexer/stellar_indexer.py
@@ -1,0 +1,85 @@
+"""Stellar/Soroban contract event indexer."""
+
+import logging
+import os
+from datetime import datetime
+
+from stellar_sdk import SorobanServer
+from stellar_sdk.exceptions import SdkError
+
+from .base import BaseIndexer, IndexedEvent
+
+logger = logging.getLogger(__name__)
+
+
+class StellarIndexer(BaseIndexer):
+    """Indexes events from ChainBridge Soroban contracts."""
+
+    def __init__(self):
+        super().__init__(chain="stellar")
+        rpc_url = os.getenv(
+            "SOROBAN_RPC_URL", "https://soroban-testnet.stellar.org"
+        )
+        self.server = SorobanServer(rpc_url)
+        self.contract_id = os.getenv("CHAINBRIDGE_CONTRACT_ID", "")
+
+    async def get_latest_block(self) -> int:
+        try:
+            response = self.server.get_latest_ledger()
+            return response.sequence
+        except SdkError as e:
+            logger.error("[stellar] Failed to get latest ledger: %s", e)
+            raise
+
+    async def fetch_events(
+        self, from_block: int, to_block: int
+    ) -> list[IndexedEvent]:
+        events = []
+        try:
+            response = self.server.get_events(
+                start_ledger=from_block,
+                filters=[
+                    {
+                        "type": "contract",
+                        "contractIds": [self.contract_id],
+                    }
+                ]
+                if self.contract_id
+                else [],
+                limit=200,
+            )
+
+            for event in response.events:
+                if hasattr(event, "ledger") and event.ledger > to_block:
+                    break
+
+                try:
+                    indexed = IndexedEvent(
+                        chain="stellar",
+                        event_type=str(event.topic[0]) if event.topic else "unknown",
+                        tx_hash=event.tx_hash if hasattr(event, "tx_hash") else "",
+                        block_number=event.ledger,
+                        contract_address=getattr(event, "contract_id", None),
+                        data={
+                            "topic": [str(t) for t in event.topic],
+                            "value": str(event.value) if event.value else None,
+                        },
+                        timestamp=datetime.utcnow(),
+                    )
+                    events.append(indexed)
+                except Exception as e:
+                    logger.warning("[stellar] Failed to parse event: %s", e)
+
+        except SdkError as e:
+            logger.error("[stellar] Failed to fetch events: %s", e)
+            raise
+
+        return events
+
+    async def handle_reorg(self, reorg_block: int) -> None:
+        # Stellar/Soroban doesn't have traditional reorgs like PoW chains.
+        # Ledger finality is near-instant. Log and continue.
+        logger.info(
+            "[stellar] Reorg handling not needed (instant finality), ledger %d",
+            reorg_block,
+        )


### PR DESCRIPTION
## Description
Create event indexer monitoring Stellar, Bitcoin, and Ethereum for ChainBridge events.

## Changes

### BaseIndexer (backend/app/indexer/base.py)
- Standardized IndexedEvent format across all chains
- Block-range polling with async event queue
- IndexerStatus tracking and reorg handling interface

### Chain-Specific Indexers
- **StellarIndexer**: Soroban contract events via RPC, instant finality
- **BitcoinIndexer**: JSON-RPC to Bitcoin node, OP_RETURN scanning, 6-block confirmation
- **EthereumIndexer**: eth_getLogs for contract events, 12-block confirmation

### IndexerManager (backend/app/indexer/manager.py)
- Orchestrates all indexers as concurrent async tasks
- Unified status API: `get_all_status()`, `get_status(chain)`
- Historical catch-up via `catch_up(chain, from_block, to_block)`
- Graceful start/stop lifecycle

## How to test
- Configure RPC URLs in .env for each chain
- Start manager: `await manager.start_all()`
- Check status: `manager.get_all_status()`

Closes #24