### PR TITLE
feat(frontend): SEO metadata baseline, 404/maintenance pages, keyboard & screen reader accessibility

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -753,6 +753,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1184,6 +1185,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1795,6 +1797,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2513,6 +2516,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2694,6 +2698,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4195,6 +4200,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5028,6 +5034,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5260,6 +5267,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5272,6 +5280,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6259,6 +6268,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6458,6 +6468,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6586,6 +6597,7 @@
       "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.1.0.tgz",
       "integrity": "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": ">=5"
       },

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,5 +1,19 @@
+import type { Metadata } from "next";
 import { Card, Badge, Button } from "@/components/ui";
 import { Info, ShieldCheck, Zap, Globe, Layers, ArrowRight } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "Learn how ChainBridge uses Hash Time-Locked Contracts (HTLCs) to enable trustless, non-custodial atomic swaps across Stellar, Bitcoin, and Ethereum.",
+  alternates: { canonical: "/about" },
+  openGraph: {
+    title: "About ChainBridge",
+    description:
+      "Learn how ChainBridge uses HTLCs for trustless, non-custodial atomic swaps across Stellar, Bitcoin, and Ethereum.",
+    url: "/about",
+  },
+};
 
 export default function AboutPage() {
   return (

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Admin Dashboard",
+  description: "ChainBridge admin dashboard for monitoring protocol health, HTLCs, and disputes.",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+  description:
+    "Manage your ChainBridge profile, wallet preferences, and cross-chain settings from a single dashboard.",
+  alternates: { canonical: "/dashboard" },
+  openGraph: {
+    title: "User Dashboard | ChainBridge",
+    description: "Manage your profile, preferences, and wallet settings on ChainBridge.",
+    url: "/dashboard",
+  },
+};
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -14,7 +14,7 @@ export default function DashboardPage() {
         <h2 className="text-xl font-semibold text-text-primary">Profile</h2>
         
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-           <Input label="Wallet Address" disabled value="0x123...abc" rightElement={<CopyButton text={"0x123...abc"} />} />
+           <Input label="Wallet Address" disabled value="0x123...abc" rightElement={<CopyButton value={"0x123...abc"} />} />
            <Input label="Display Name" placeholder="e.g. Satoshi" />
            <Input label="Email" placeholder="your@email.com" />
         </div>

--- a/frontend/src/app/htlcs/layout.tsx
+++ b/frontend/src/app/htlcs/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "HTLC Manager",
+  description:
+    "Inspect, claim, and refund your Hash Time-Locked Contracts on Stellar, Bitcoin, and Ethereum via ChainBridge.",
+  alternates: { canonical: "/htlcs" },
+  openGraph: {
+    title: "HTLC Manager | ChainBridge",
+    description:
+      "Inspect, claim, and refund your Hash Time-Locked Contracts across Stellar, Bitcoin, and Ethereum.",
+    url: "/htlcs",
+  },
+};
+
+export default function HtlcsLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -16,11 +16,49 @@ const spaceGrotesk = Space_Grotesk({
   variable: "--font-space",
 });
 
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://chainbridge.io";
+
 export const metadata: Metadata = {
-  title: "ChainBridge | Trustless Cross-Chain Swaps",
-  description: "Secure, non-custodial atomic swaps on Stellar, Bitcoin, and Ethereum using HTLCs.",
+  metadataBase: new URL(BASE_URL),
+  title: {
+    default: "ChainBridge | Trustless Cross-Chain Swaps",
+    template: "%s | ChainBridge",
+  },
+  description:
+    "Secure, non-custodial atomic swaps on Stellar, Bitcoin, and Ethereum using HTLCs. Zero counterparty risk, no intermediaries.",
+  keywords: ["cross-chain", "atomic swap", "HTLC", "Stellar", "Bitcoin", "Ethereum", "DeFi"],
+  authors: [{ name: "ChainBridge" }],
+  creator: "ChainBridge",
   icons: {
     icon: "/favicon.ico",
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: BASE_URL,
+    siteName: "ChainBridge",
+    title: "ChainBridge | Trustless Cross-Chain Swaps",
+    description:
+      "Secure, non-custodial atomic swaps on Stellar, Bitcoin, and Ethereum using HTLCs. Zero counterparty risk, no intermediaries.",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "ChainBridge — Trustless Cross-Chain Swaps",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "ChainBridge | Trustless Cross-Chain Swaps",
+    description:
+      "Secure, non-custodial atomic swaps on Stellar, Bitcoin, and Ethereum using HTLCs.",
+    images: ["/og-image.png"],
+    creator: "@chainbridge_io",
+  },
+  alternates: {
+    canonical: BASE_URL,
   },
 };
 
@@ -38,10 +76,19 @@ export default function RootLayout({
           spaceGrotesk.variable
         )}
       >
+        {/* Skip-to-main link — visible on keyboard focus, hidden otherwise */}
+        <a
+          href="#main-content"
+          className="skip-to-main"
+        >
+          Skip to main content
+        </a>
         <Providers>
           <div className="relative flex min-h-screen flex-col">
             <Navbar />
-            <main className="flex-1">{children}</main>
+            <main id="main-content" className="flex-1" tabIndex={-1}>
+              {children}
+            </main>
             <Footer />
           </div>
         </Providers>

--- a/frontend/src/app/maintenance/page.tsx
+++ b/frontend/src/app/maintenance/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from "next";
+import { Wrench, Clock, ArrowUpRight } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Under Maintenance | ChainBridge",
+  description:
+    "ChainBridge is temporarily down for scheduled maintenance. We'll be back shortly.",
+  robots: { index: false, follow: false },
+};
+
+export default function MaintenancePage() {
+  return (
+    <main
+      id="main-content"
+      className="flex min-h-screen flex-col items-center justify-center bg-background px-4 text-center"
+      aria-labelledby="maintenance-heading"
+    >
+      {/* Ambient glow */}
+      <div
+        className="absolute -top-[20%] left-1/2 -translate-x-1/2 h-[40%] w-[60%] rounded-full bg-brand-500/10 blur-[140px]"
+        aria-hidden="true"
+      />
+
+      <div className="relative z-10 flex flex-col items-center">
+        {/* Icon */}
+        <div
+          className="mb-6 flex h-20 w-20 items-center justify-center rounded-2xl border border-brand-500/30 bg-brand-500/10 text-brand-500"
+          aria-hidden="true"
+        >
+          <Wrench className="h-10 w-10" />
+        </div>
+
+        {/* Status badge */}
+        <span className="mb-4 inline-flex items-center gap-2 rounded-full border border-border bg-surface-raised px-3 py-1 text-xs font-semibold uppercase tracking-widest text-text-muted">
+          <span className="h-1.5 w-1.5 rounded-full bg-yellow-400" aria-hidden="true" />
+          Scheduled Maintenance
+        </span>
+
+        <h1
+          id="maintenance-heading"
+          className="text-4xl font-extrabold tracking-tight text-text-primary sm:text-5xl"
+        >
+          We&apos;ll Be Right Back
+        </h1>
+
+        <p className="mt-4 max-w-md text-base leading-relaxed text-text-secondary">
+          ChainBridge is undergoing scheduled maintenance to improve reliability and add new
+          features. All funds are safe and contracts remain on-chain.
+        </p>
+
+        {/* Timeline */}
+        <div className="mt-8 flex items-center gap-2 rounded-xl border border-border bg-surface-overlay px-5 py-3 text-sm text-text-secondary">
+          <Clock className="h-4 w-4 shrink-0 text-brand-500" aria-hidden="true" />
+          <span>Expected downtime: under 2 hours</span>
+        </div>
+
+        {/* External status link */}
+        <a
+          href="https://status.chainbridge.io"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-6 inline-flex items-center gap-1.5 text-sm font-medium text-brand-500 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          Check live status
+          <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/marketplace/layout.tsx
+++ b/frontend/src/app/marketplace/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Marketplace",
+  description:
+    "Browse the ChainBridge order book and take open cross-chain swap orders. Permissionless, trustless trading via HTLC contracts.",
+  alternates: { canonical: "/marketplace" },
+  openGraph: {
+    title: "Order Book Marketplace | ChainBridge",
+    description:
+      "Browse and fill open cross-chain swap orders. Permissionless, trustless trading via HTLC contracts.",
+    url: "/marketplace",
+  },
+};
+
+export default function MarketplaceLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,16 +1,33 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Compass, ArrowRight } from "lucide-react";
+import { Compass, ArrowRight, Home } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Page Not Found | ChainBridge",
+  description: "The page you were looking for does not exist. Return to ChainBridge.",
+  robots: { index: false, follow: false },
+};
 
 export default function NotFound() {
   return (
-    <div className="container mx-auto flex h-[70vh] flex-col items-center justify-center px-4 text-center">
-      <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-surface-overlay border border-border text-text-muted">
+    <main
+      id="main-content"
+      className="container mx-auto flex min-h-[70vh] flex-col items-center justify-center px-4 text-center"
+      aria-labelledby="notfound-heading"
+    >
+      <div
+        className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-surface-overlay border border-border text-text-muted"
+        aria-hidden="true"
+      >
         <Compass className="h-10 w-10" />
       </div>
 
-      <h1 className="text-4xl font-extrabold tracking-tight text-text-primary">
-        Destination Unknown
+      <h1
+        id="notfound-heading"
+        className="text-4xl font-extrabold tracking-tight text-text-primary"
+      >
+        404 — Destination Unknown
       </h1>
 
       <p className="mt-4 max-w-md text-text-secondary">
@@ -18,14 +35,23 @@ export default function NotFound() {
         chain.
       </p>
 
-      <div className="mt-10">
+      <nav
+        className="mt-10 flex flex-wrap items-center justify-center gap-3"
+        aria-label="Recovery navigation"
+      >
         <Link href="/">
           <Button size="lg" className="rounded-xl px-8">
+            <Home className="mr-2 h-5 w-5" aria-hidden="true" />
             Return to Bridge
-            <ArrowRight className="ml-2 h-5 w-5" />
           </Button>
         </Link>
-      </div>
-    </div>
+        <Link href="/swap">
+          <Button variant="outline" size="lg" className="rounded-xl px-8">
+            Go to Swap
+            <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
+          </Button>
+        </Link>
+      </nav>
+    </main>
   );
 }

--- a/frontend/src/app/orders/layout.tsx
+++ b/frontend/src/app/orders/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "My Orders",
+  description:
+    "View and manage your open and historical cross-chain swap orders on ChainBridge.",
+  alternates: { canonical: "/orders" },
+  openGraph: {
+    title: "My Orders | ChainBridge",
+    description: "View and manage your open and historical cross-chain swap orders on ChainBridge.",
+    url: "/orders",
+  },
+};
+
+export default function OrdersLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/protocol/layout.tsx
+++ b/frontend/src/app/protocol/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Protocol",
+  description:
+    "Explore ChainBridge protocol features: governance, liquidity pools, referral campaigns, and advanced order modes.",
+  alternates: { canonical: "/protocol" },
+  openGraph: {
+    title: "Protocol Explorer | ChainBridge",
+    description:
+      "Governance, liquidity pools, referral campaigns, and advanced order modes on ChainBridge.",
+    url: "/protocol",
+  },
+};
+
+export default function ProtocolLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/settings/layout.tsx
+++ b/frontend/src/app/settings/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Settings",
+  description:
+    "Configure ChainBridge display preferences, realtime notifications, and preferred network mode.",
+  alternates: { canonical: "/settings" },
+  openGraph: {
+    title: "Settings | ChainBridge",
+    description:
+      "Configure display preferences, realtime notifications, and preferred network mode on ChainBridge.",
+    url: "/settings",
+  },
+  robots: { index: false, follow: false },
+};
+
+export default function SettingsLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/swap/layout.tsx
+++ b/frontend/src/app/swap/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Swap",
+  description:
+    "Launch ChainBridge's Swap Wizard to exchange assets trustlessly between Stellar, Bitcoin, and Ethereum with no intermediaries.",
+  alternates: { canonical: "/swap" },
+  openGraph: {
+    title: "Cross-Chain Swap | ChainBridge",
+    description:
+      "Exchange assets trustlessly between Stellar, Bitcoin, and Ethereum using HTLC atomic swaps.",
+    url: "/swap",
+  },
+};
+
+export default function SwapLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/transactions/layout.tsx
+++ b/frontend/src/app/transactions/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Transaction Explorer",
+  description:
+    "View live and historical cross-chain swap transactions processed by ChainBridge, with on-chain proof verification.",
+  alternates: { canonical: "/transactions" },
+  openGraph: {
+    title: "Transaction Explorer | ChainBridge",
+    description:
+      "Live and historical cross-chain swap transactions with on-chain proof verification.",
+    url: "/transactions",
+  },
+};
+
+export default function TransactionsLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -7,12 +7,12 @@ export function Footer() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="border-t border-border bg-surface/50 py-12">
+    <footer className="border-t border-border bg-surface/50 py-12" aria-label="Site footer">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 gap-8 md:grid-cols-4">
           {/* Brand */}
           <div className="md:col-span-1">
-            <Link href="/" className="flex items-center gap-2">
+            <Link href="/" className="flex items-center gap-2" aria-label="ChainBridge home">
               <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-brand-gradient text-white">
                 <Layers className="h-4 w-4" />
               </div>
@@ -27,7 +27,7 @@ export function Footer() {
           </div>
 
           {/* Links */}
-          <div>
+          <nav aria-label="Platform links">
             <h3 className="text-sm font-semibold text-text-primary">Platform</h3>
             <ul className="mt-4 space-y-2 text-sm text-text-secondary">
               <li>
@@ -46,50 +46,64 @@ export function Footer() {
                 </Link>
               </li>
             </ul>
-          </div>
+          </nav>
 
-          <div>
+          <nav aria-label="Ecosystem links">
             <h3 className="text-sm font-semibold text-text-primary">Ecosystem</h3>
             <ul className="mt-4 space-y-2 text-sm text-text-secondary">
               <li>
                 <a
                   href="https://stellar.org"
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="flex items-center gap-1 hover:text-brand-500 transition"
                 >
-                  Stellar <ExternalLink className="h-3 w-3" />
+                  Stellar <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                  <span className="sr-only">(opens in new tab)</span>
                 </a>
               </li>
               <li>
                 <a
                   href="https://ethereum.org"
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="flex items-center gap-1 hover:text-brand-500 transition"
                 >
-                  Ethereum <ExternalLink className="h-3 w-3" />
+                  Ethereum <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                  <span className="sr-only">(opens in new tab)</span>
                 </a>
               </li>
               <li>
                 <a
                   href="https://bitcoin.org"
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="flex items-center gap-1 hover:text-brand-500 transition"
                 >
-                  Bitcoin <ExternalLink className="h-3 w-3" />
+                  Bitcoin <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                  <span className="sr-only">(opens in new tab)</span>
                 </a>
               </li>
             </ul>
-          </div>
+          </nav>
 
           {/* Social */}
           <div>
             <h3 className="text-sm font-semibold text-text-primary">Stay Connected</h3>
             <div className="mt-4 flex gap-4">
-              <a href="#" className="text-text-muted hover:text-text-primary transition">
-                <Globe className="h-5 w-5" />
+              <a
+                href="#"
+                className="text-text-muted hover:text-text-primary transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm"
+                aria-label="ChainBridge website"
+              >
+                <Globe className="h-5 w-5" aria-hidden="true" />
               </a>
-              <a href="#" className="text-text-muted hover:text-text-primary transition">
-                <Share2 className="h-5 w-5" />
+              <a
+                href="#"
+                className="text-text-muted hover:text-text-primary transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm"
+                aria-label="Share ChainBridge"
+              >
+                <Share2 className="h-5 w-5" aria-hidden="true" />
               </a>
             </div>
           </div>

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -28,7 +28,10 @@ export function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <nav className="sticky top-0 z-40 w-full border-b border-border bg-background/80 backdrop-blur-md">
+    <nav
+      className="sticky top-0 z-40 w-full border-b border-border bg-background/80 backdrop-blur-md"
+      aria-label="Main navigation"
+    >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex h-16 items-center justify-between">
           {/* Left Side: Logo & Desktop Links */}
@@ -47,6 +50,7 @@ export function Navbar() {
                 <Link
                   key={link.href}
                   href={link.href}
+                  aria-current={pathname === link.href ? "page" : undefined}
                   className={cn(
                     "rounded-lg px-3 py-2 text-sm font-medium transition-colors",
                     pathname === link.href
@@ -95,9 +99,11 @@ export function Navbar() {
             <button
               onClick={() => setIsOpen(!isOpen)}
               className="flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-surface-overlay text-text-primary md:hidden"
-              aria-label="Toggle menu"
+              aria-label="Toggle navigation menu"
+              aria-expanded={isOpen}
+              aria-controls="mobile-nav"
             >
-              {isOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+              {isOpen ? <X className="h-5 w-5" aria-hidden="true" /> : <Menu className="h-5 w-5" aria-hidden="true" />}
             </button>
           </div>
         </div>
@@ -105,10 +111,12 @@ export function Navbar() {
 
       {/* Mobile Menu Drawer */}
       <div
+        id="mobile-nav"
         className={cn(
           "absolute left-0 right-0 top-16 z-50 overflow-hidden border-b border-border bg-background/95 backdrop-blur-xl transition-all duration-300 ease-in-out md:hidden",
           isOpen ? "max-h-[400px] py-4 shadow-xl" : "max-h-0 py-0 border-none"
         )}
+        aria-hidden={!isOpen}
       >
         <div className="container mx-auto px-4 space-y-2">
           {NAV_LINKS.map((link) => (
@@ -116,6 +124,7 @@ export function Navbar() {
               key={link.href}
               href={link.href}
               onClick={() => setIsOpen(false)}
+              aria-current={pathname === link.href ? "page" : undefined}
               className={cn(
                 "flex items-center rounded-xl px-4 py-3 text-base font-medium transition-all",
                 pathname === link.href

--- a/frontend/src/components/swap/SwapReviewSummary.tsx
+++ b/frontend/src/components/swap/SwapReviewSummary.tsx
@@ -33,7 +33,7 @@ export function SwapReviewSummary({ onConfirm, onCancel, isConfirming, swapDetai
             <p className="text-sm text-text-secondary mb-1">Pay</p>
             <div className="flex items-center gap-2">
               <span className="text-2xl font-semibold text-text-primary">{swapDetails.fromAmount}</span>
-              <Badge variant="outline">{swapDetails.fromAsset}</Badge>
+              <Badge variant="default">{swapDetails.fromAsset}</Badge>
             </div>
             <p className="text-xs text-text-muted mt-1">on {swapDetails.fromChain}</p>
           </div>
@@ -48,7 +48,7 @@ export function SwapReviewSummary({ onConfirm, onCancel, isConfirming, swapDetai
             <p className="text-sm text-text-secondary mb-1">Receive</p>
             <div className="flex items-center gap-2">
               <span className="text-2xl font-semibold text-text-primary">{swapDetails.toAmount}</span>
-              <Badge variant="outline">{swapDetails.toAsset}</Badge>
+              <Badge variant="default">{swapDetails.toAsset}</Badge>
             </div>
             <p className="text-xs text-text-muted mt-1">on {swapDetails.toChain}</p>
           </div>

--- a/frontend/src/components/ui/empty-state.tsx
+++ b/frontend/src/components/ui/empty-state.tsx
@@ -47,7 +47,10 @@ export function EmptyState({
         className
       )}
     >
-      <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full border border-border bg-surface-overlay text-text-muted">
+      <div
+        className="mx-auto flex h-14 w-14 items-center justify-center rounded-full border border-border bg-surface-overlay text-text-muted"
+        aria-hidden="true"
+      >
         {icon}
       </div>
       <h3 className="mt-5 text-xl font-bold text-text-primary">{title}</h3>

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -12,6 +12,10 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, label, error, hint, leftElement, rightElement, id, ...props }, ref) => {
     const inputId = id ?? label?.toLowerCase().replace(/\s+/g, "-");
+    const errorId = inputId ? `${inputId}-error` : undefined;
+    const hintId = inputId ? `${inputId}-hint` : undefined;
+    const describedBy =
+      (error ? errorId : undefined) ?? (hint ? hintId : undefined);
 
     return (
       <div className="flex flex-col gap-1.5">
@@ -22,11 +26,13 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         )}
         <div className="relative flex items-center">
           {leftElement && (
-            <div className="absolute left-3 flex items-center text-text-muted">{leftElement}</div>
+            <div className="absolute left-3 flex items-center text-text-muted" aria-hidden="true">{leftElement}</div>
           )}
           <input
             ref={ref}
             id={inputId}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={describedBy}
             className={cn(
               "w-full rounded-xl border border-border bg-surface-raised px-4 py-2.5 text-sm text-text-primary",
               "placeholder:text-text-muted",
@@ -41,11 +47,19 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             {...props}
           />
           {rightElement && (
-            <div className="absolute right-3 flex items-center text-text-muted">{rightElement}</div>
+            <div className="absolute right-3 flex items-center text-text-muted" aria-hidden="true">{rightElement}</div>
           )}
         </div>
-        {error && <p className="text-xs text-red-400">{error}</p>}
-        {hint && !error && <p className="text-xs text-text-muted">{hint}</p>}
+        {error && (
+          <p id={errorId} role="alert" className="text-xs text-red-400">
+            {error}
+          </p>
+        )}
+        {hint && !error && (
+          <p id={hintId} className="text-xs text-text-muted">
+            {hint}
+          </p>
+        )}
       </div>
     );
   }

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useId } from "react";
 import { X } from "lucide-react";
 import { createPortal } from "react-dom";
 
@@ -21,6 +21,15 @@ const sizeStyles = {
   lg: "max-w-2xl",
 };
 
+/** Returns all keyboard-focusable elements within a container. */
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )
+  );
+}
+
 export function Modal({
   open,
   onClose,
@@ -31,24 +40,71 @@ export function Modal({
   className,
 }: ModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  /** Element that had focus before the modal opened — restored on close. */
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const uid = useId();
+  const titleId = `${uid}-title`;
+  const descId = `${uid}-desc`;
 
-  // Close on Escape
+  // Remember the triggering element so we can restore focus on close.
+  useEffect(() => {
+    if (open) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+    }
+  }, [open]);
+
+  // Move focus to first focusable element inside the modal when opened.
+  useEffect(() => {
+    if (!open || !panelRef.current) return;
+    const focusable = getFocusableElements(panelRef.current);
+    (focusable[0] ?? panelRef.current).focus();
+  }, [open]);
+
+  // Restore focus to the triggering element when the modal closes.
+  useEffect(() => {
+    if (!open && previousFocusRef.current) {
+      previousFocusRef.current.focus();
+      previousFocusRef.current = null;
+    }
+  }, [open]);
+
+  // Close on Escape and implement focus trap on Tab / Shift+Tab.
   useEffect(() => {
     if (!open) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key === "Tab" && panelRef.current) {
+        const focusable = getFocusableElements(panelRef.current);
+        if (focusable.length === 0) {
+          e.preventDefault();
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
     };
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
   }, [open, onClose]);
 
-  // Prevent body scroll
+  // Prevent body scroll while modal is open.
   useEffect(() => {
-    if (open) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
+    document.body.style.overflow = open ? "hidden" : "";
     return () => {
       document.body.style.overflow = "";
     };
@@ -63,11 +119,21 @@ export function Modal({
       onClick={(e) => e.target === overlayRef.current && onClose()}
     >
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-fade-in" />
-      {/* Panel */}
       <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-fade-in"
+        aria-hidden="true"
+      />
+      {/* Dialog panel */}
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? titleId : undefined}
+        aria-describedby={description ? descId : undefined}
+        tabIndex={-1}
         className={cn(
           "relative z-10 w-full animate-slide-up rounded-2xl border border-border bg-surface-raised shadow-card-dark",
+          "focus:outline-none",
           sizeStyles[size],
           className
         )}
@@ -77,15 +143,23 @@ export function Modal({
           <div className="border-b border-border px-6 py-4">
             <div className="flex items-start justify-between gap-4">
               <div>
-                {title && <h2 className="text-lg font-semibold text-text-primary">{title}</h2>}
-                {description && <p className="mt-0.5 text-sm text-text-secondary">{description}</p>}
+                {title && (
+                  <h2 id={titleId} className="text-lg font-semibold text-text-primary">
+                    {title}
+                  </h2>
+                )}
+                {description && (
+                  <p id={descId} className="mt-0.5 text-sm text-text-secondary">
+                    {description}
+                  </p>
+                )}
               </div>
               <button
                 onClick={onClose}
-                className="rounded-lg p-1.5 text-text-muted transition hover:bg-surface-overlay hover:text-text-primary"
+                className="rounded-lg p-1.5 text-text-muted transition hover:bg-surface-overlay hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 aria-label="Close modal"
               >
-                <X className="h-4 w-4" />
+                <X className="h-4 w-4" aria-hidden="true" />
               </button>
             </div>
           </div>
@@ -97,3 +171,4 @@ export function Modal({
     document.body
   );
 }
+

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -12,6 +12,10 @@ interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
   ({ className, label, error, hint, options, id, ...props }, ref) => {
     const selectId = id ?? label?.toLowerCase().replace(/\s+/g, "-");
+    const errorId = selectId ? `${selectId}-error` : undefined;
+    const hintId = selectId ? `${selectId}-hint` : undefined;
+    const describedBy =
+      (error ? errorId : undefined) ?? (hint ? hintId : undefined);
 
     return (
       <div className="flex flex-col gap-1.5 w-full">
@@ -24,6 +28,8 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           <select
             ref={ref}
             id={selectId}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={describedBy}
             className={cn(
               "w-full appearance-none rounded-xl border border-border bg-surface-raised px-4 py-2.5 text-sm text-text-primary",
               "transition-all duration-150",
@@ -40,12 +46,20 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
               </option>
             ))}
           </select>
-          <div className="pointer-events-none absolute right-4 flex items-center text-text-muted">
+          <div className="pointer-events-none absolute right-4 flex items-center text-text-muted" aria-hidden="true">
              <ChevronDown className="h-4 w-4" />
           </div>
         </div>
-        {error && <p className="text-xs text-red-400">{error}</p>}
-        {hint && !error && <p className="text-xs text-text-muted">{hint}</p>}
+        {error && (
+          <p id={errorId} role="alert" className="text-xs text-red-400">
+            {error}
+          </p>
+        )}
+        {hint && !error && (
+          <p id={hintId} className="text-xs text-text-muted">
+            {hint}
+          </p>
+        )}
       </div>
     );
   }

--- a/frontend/src/components/ui/spinner.tsx
+++ b/frontend/src/components/ui/spinner.tsx
@@ -14,13 +14,16 @@ const sizeStyles = {
 export function Spinner({ size = "md", className }: SpinnerProps) {
   return (
     <div
+      role="status"
+      aria-label="Loading"
       className={cn(
         "animate-spin rounded-full border-text-muted border-t-brand-500",
         sizeStyles[size],
         className
       )}
-      aria-label="Loading"
-    />
+    >
+      <span className="sr-only">Loading…</span>
+    </div>
   );
 }
 
@@ -33,10 +36,12 @@ interface LoadingStateProps {
 export function LoadingState({ label = "Loading…", size = "md", className }: LoadingStateProps) {
   return (
     <div
+      role="status"
+      aria-live="polite"
       className={cn("flex flex-col items-center justify-center gap-3 py-12 text-center", className)}
     >
       <Spinner size={size} />
-      <p className="text-sm text-text-muted animate-pulse">{label}</p>
+      <p className="text-sm text-text-muted animate-pulse" aria-hidden="true">{label}</p>
     </div>
   );
 }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -114,7 +114,10 @@ export function createApiClient({ basePath, getHeaders }: ApiClientOptions) {
   });
 
   instance.interceptors.request.use((request) => {
-    request.headers = mergeHeaders(request.headers, getHeaders?.());
+    const merged = mergeHeaders(request.headers, getHeaders?.());
+    if (merged) {
+      request.headers = merged as typeof request.headers;
+    }
     return request;
   });
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * When MAINTENANCE_MODE=true is set in the server environment, every request
+ * (except the maintenance page itself and static assets) is redirected to
+ * /maintenance so visitors see a polished status page instead of errors.
+ */
+export function middleware(request: NextRequest) {
+  const isMaintenanceMode = process.env.MAINTENANCE_MODE === "true";
+  const { pathname } = request.nextUrl;
+
+  if (
+    isMaintenanceMode &&
+    !pathname.startsWith("/maintenance") &&
+    !pathname.startsWith("/_next") &&
+    !pathname.startsWith("/favicon")
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/maintenance";
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon\\.ico).*)"],
+};

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -51,6 +51,13 @@
     border-color: hsl(var(--border));
   }
 
+  /* Ensure all interactive elements have a visible focus ring */
+  :focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
   html {
     scroll-behavior: smooth;
     -webkit-font-smoothing: antialiased;
@@ -101,6 +108,26 @@
 
 /* ===== COMPONENT UTILITIES ===== */
 @layer components {
+  /* Skip-to-main navigation link (visible only on focus) */
+  .skip-to-main {
+    position: absolute;
+    top: -100%;
+    left: 0;
+    padding: 0.6rem 1.25rem;
+    background: hsl(var(--brand));
+    color: hsl(var(--brand-foreground, 0 0% 100%));
+    font-size: 0.875rem;
+    font-weight: 600;
+    z-index: 9999;
+    border-radius: 0 0 0.5rem 0;
+    transition: top 0.15s ease;
+  }
+  .skip-to-main:focus {
+    top: 0;
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+
   .glass {
     background: hsl(var(--surface-raised) / 0.7);
     backdrop-filter: blur(12px);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -23,6 +23,7 @@
       "@/components/*": ["./src/components/*"],
       "@/lib/*": ["./src/lib/*"],
       "@/hooks/*": ["./src/hooks/*"],
+      "@/styles/*": ["./src/styles/*"],
       "@/types": ["./src/types/index.ts"],
       "@/types/*": ["./src/types/*"]
     },


### PR DESCRIPTION
## Summary

This PR closes four frontend issues by adding foundational SEO metadata, polished error pages, and a full keyboard + screen reader accessibility pass across the entire frontend.

Closes #158
Closes #159
Closes #161
Closes #162

---

## #158 — Implement 404 and maintenance pages

- **`not-found.tsx`** — enhanced with `Metadata` export, semantic `<main>` with `aria-labelledby`, explicit `404` in the heading, and two recovery links (home + swap).
- **New `/maintenance/page.tsx`** — polished maintenance page with status badge, ambient glow, expected-downtime notice, and an external status-page link.
- **New `src/middleware.ts`** — when `MAINTENANCE_MODE=true` is set in the server environment, all routes are transparently redirected to `/maintenance`. Static assets and the maintenance page itself are excluded. Fully compatible with Next.js App Router conventions.

## #159 — Add SEO and social metadata baseline

- **Root `layout.tsx`** — `metadataBase` set via `NEXT_PUBLIC_SITE_URL`, title template (`%s | ChainBridge`), full **OpenGraph** (type, locale, url, siteName, image) and **Twitter card** (summary_large_image) config, global canonical URL.
- **Per-route `layout.tsx`** files created for every major route: `/swap`, `/dashboard`, `/marketplace`, `/orders`, `/htlcs`, `/protocol`, `/settings`, `/transactions`, `/admin` — each exports its own `title`, `description`, `alternates.canonical`, and OpenGraph overrides.
- Static server-component pages (`/about`) export `Metadata` directly from the page file.
- Admin and Settings pages are marked `robots: { index: false }`.
- Added `@/styles/*` path alias to `tsconfig.json` (was missing, caused build failure).

## #161 — Keyboard accessibility pass for interactive controls

- **`modal.tsx`** — complete focus trap (Tab / Shift+Tab cycle confined to dialog), focus auto-moved to first focusable element on open, focus restored to the triggering element on close. Uses `useId` for stable `aria-labelledby` / `aria-describedby` IDs. Close button has `focus-visible` ring.
- **`Navbar.tsx`** — `aria-expanded` + `aria-controls` on mobile menu toggle, `aria-hidden` on collapsed drawer, `aria-current=page` on active links (desktop and mobile), `aria-label` on `<nav>`.
- **`Footer.tsx`** — `rel="noopener noreferrer"` on all external links, `aria-label` on icon-only social links, platform/ecosystem links wrapped in `<nav>` with `aria-label`.
- **`layout.tsx`** — skip-to-main link (absolutely positioned, reveals on keyboard focus) targets `#main-content`; `<main>` gets `id="main-content"` and `tabIndex={-1}`.
- **`globals.css`** — global `:focus-visible` outline rule (2 px brand ring) ensures every interactive element has a visible focus style; `.skip-to-main` utility class added.

## #162 — Screen reader accessibility audit

- **`input.tsx`** — `aria-invalid` when errored, `aria-describedby` linked to scoped error/hint element IDs, `role="alert"` on error messages, `aria-hidden` on decorative side-slot containers.
- **`select.tsx`** — same `aria-invalid` / `aria-describedby` / `role="alert"` pattern as Input.
- **`spinner.tsx`** — `role="status"` on Spinner with a visually-hidden `<span>` for announcement; `LoadingState` gains `aria-live="polite"` and hides the visible label from AT to avoid duplication.
- **`empty-state.tsx`** — decorative icon container marked `aria-hidden="true"`.
- `ToastProvider` already had a correct `role="status" aria-live="polite"` live region; left unchanged.

## Pre-existing build fixes (unblocked CI)

| File | Fix |
|------|-----|
| `dashboard/page.tsx` | `CopyButton text=` → `value=` (wrong prop name) |
| `SwapReviewSummary.tsx` | `Badge variant="outline"` → `"default"` (variant didn't exist) |
| `api/client.ts` | `AxiosRequestHeaders` undefined type mismatch on interceptor |

## Testing

- `npx next build` — ✅ passes, 16 static pages generated, no type errors
- All ESLint warnings are pre-existing hook dependency issues unrelated to this PR
- Middleware tested locally: setting `MAINTENANCE_MODE=true` redirects all pages to `/maintenance`