### PR TITLE
feat: mobile drawer with swipe-to-close, focus trap, and header/body/…

### DIFF
--- a/frontend/src/components/layout/MobileNavDrawer.tsx
+++ b/frontend/src/components/layout/MobileNavDrawer.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import Link from "next/link";
+import { Layers, X } from "lucide-react";
+import { Drawer } from "@/components/ui/drawer";
+import { DarkModeToggle } from "./DarkModeToggle";
+import { WalletConnect } from "@/components/swap/WalletConnect";
+import { CommandPalette } from "./CommandPalette";
+import { NAV_LINKS } from "./navigation";
+import { useI18n } from "@/components/i18n/I18nProvider";
+import { useSettingsStore } from "@/hooks/useSettings";
+import { SUPPORTED_LOCALES, stripLocaleFromPathname } from "@/lib/i18n/config";
+import { usePathname, useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+interface MobileNavDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function MobileNavDrawer({ open, onClose }: MobileNavDrawerProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const normalizedPathname = stripLocaleFromPathname(pathname);
+  const { t, localizePath } = useI18n();
+  const networkMode = useSettingsStore((s) => s.settings.network.mode);
+
+  const header = (
+    <div className="flex items-center justify-between border-b border-border px-5 py-4">
+      <Link
+        href={localizePath("/")}
+        onClick={onClose}
+        className="flex items-center gap-2 transition hover:opacity-80"
+      >
+        <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-brand-gradient text-white shadow-glow-sm">
+          <Layers className="h-4 w-4" />
+        </div>
+        <span className="text-lg font-bold tracking-tight text-text-primary">ChainBridge</span>
+      </Link>
+      <button
+        onClick={onClose}
+        aria-label="Close navigation menu"
+        className="rounded-lg p-2 text-text-muted transition hover:bg-surface-overlay hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <X className="h-5 w-5" aria-hidden="true" />
+      </button>
+    </div>
+  );
+
+  const footer = (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-text-secondary">Theme</span>
+        <DarkModeToggle />
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-text-secondary">Language</span>
+        <select
+          aria-label="Language selector"
+          value={pathname.split("/").filter(Boolean)[0] || "en"}
+          onChange={(e) => {
+            const base = stripLocaleFromPathname(pathname);
+            router.push(`/${e.target.value}${base === "/" ? "" : base}`);
+            onClose();
+          }}
+          className="rounded-lg border border-border bg-surface-overlay px-2 py-1 text-xs text-text-secondary"
+        >
+          {SUPPORTED_LOCALES.map((locale) => (
+            <option key={locale} value={locale}>{locale.toUpperCase()}</option>
+          ))}
+        </select>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-text-secondary">Network</span>
+        <span className="rounded-full border border-border bg-surface-raised px-2.5 py-1 text-[10px] font-semibold uppercase tracking-widest text-text-muted">
+          {networkMode}
+        </span>
+      </div>
+      <CommandPalette />
+      <WalletConnect />
+    </div>
+  );
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      side="left"
+      size="sm"
+      header={header}
+      footer={footer}
+      aria-label="Mobile navigation"
+    >
+      <nav aria-label="Mobile navigation links">
+        <ul className="space-y-1" role="list">
+          {NAV_LINKS.map((link) => {
+            const active = normalizedPathname === link.href;
+            return (
+              <li key={link.href}>
+                <Link
+                  href={localizePath(link.href)}
+                  onClick={onClose}
+                  aria-current={active ? "page" : undefined}
+                  className={cn(
+                    "flex items-center rounded-xl px-4 py-3 text-base font-medium transition-all",
+                    active
+                      ? "bg-brand-500/10 text-brand-500"
+                      : "text-text-secondary hover:bg-surface-overlay hover:text-text-primary active:bg-surface-overlay"
+                  )}
+                >
+                  {t(link.key)}
+                  {active && (
+                    <div className="ml-auto h-1.5 w-1.5 rounded-full bg-brand-500" aria-hidden="true" />
+                  )}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </Drawer>
+  );
+}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -7,11 +7,13 @@ import { cn } from "@/lib/utils";
 import { DarkModeToggle } from "./DarkModeToggle";
 import { WalletConnect } from "../swap/WalletConnect";
 import { useSettingsStore } from "@/hooks/useSettings";
-import { Layers, Menu, X } from "lucide-react";
+import { Layers, Menu } from "lucide-react";
 import { useI18n } from "@/components/i18n/I18nProvider";
 import { NAV_LINKS } from "@/components/layout/navigation";
 import { SUPPORTED_LOCALES, stripLocaleFromPathname } from "@/lib/i18n/config";
 import { CommandPalette } from "./CommandPalette";
+import { MobileNavDrawer } from "./MobileNavDrawer";
+
 
 export function Navbar() {
   const pathname = usePathname();
@@ -116,63 +118,17 @@ export function Navbar() {
             <button
               onClick={() => setIsOpen(!isOpen)}
               className="flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-surface-overlay text-text-primary md:hidden"
-              aria-label="Toggle navigation menu"
+              aria-label="Open navigation menu"
               aria-expanded={isOpen}
-              aria-controls="mobile-nav"
+              aria-haspopup="dialog"
             >
-              {isOpen ? (
-                <X className="h-5 w-5" aria-hidden="true" />
-              ) : (
-                <Menu className="h-5 w-5" aria-hidden="true" />
-              )}
+              <Menu className="h-5 w-5" aria-hidden="true" />
             </button>
           </div>
         </div>
       </div>
 
-      {/* Mobile Menu Drawer */}
-      <div
-        id="mobile-nav"
-        className={cn(
-          "absolute left-0 right-0 top-16 z-50 overflow-hidden border-b border-border bg-background/95 backdrop-blur-xl transition-all duration-300 ease-in-out md:hidden",
-          isOpen ? "max-h-[400px] py-4 shadow-xl" : "max-h-0 py-0 border-none"
-        )}
-        aria-hidden={!isOpen}
-      >
-        <div className="container mx-auto px-4 space-y-2">
-          {NAV_LINKS.map((link) => (
-            <Link
-              key={link.href}
-              href={localizePath(link.href)}
-              onClick={() => setIsOpen(false)}
-              aria-current={normalizedPathname === link.href ? "page" : undefined}
-              className={cn(
-                "flex items-center rounded-xl px-4 py-3 text-base font-medium transition-all",
-                normalizedPathname === link.href
-                  ? "bg-brand-500/10 text-brand-500"
-                  : "text-text-secondary active:bg-surface-overlay"
-              )}
-            >
-              {t(link.key)}
-              {normalizedPathname === link.href && (
-                <div className="ml-auto h-1.5 w-1.5 rounded-full bg-brand-500" />
-              )}
-            </Link>
-          ))}
-          <div className="pt-4 pb-2">
-            <div className="flex items-center justify-between border-t border-border pt-4">
-              <span className="text-sm font-medium text-text-secondary">Theme Control</span>
-              <DarkModeToggle />
-            </div>
-            <div className="mt-4 sm:hidden">
-              <div className="mb-3">
-                <CommandPalette />
-              </div>
-              <WalletConnect />
-            </div>
-          </div>
-        </div>
-      </div>
+      <MobileNavDrawer open={isOpen} onClose={() => setIsOpen(false)} />
     </nav>
   );
 }

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -1,22 +1,27 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { useEffect, useId, useRef } from "react";
+import { useEffect, useId, useRef, useCallback } from "react";
 import { X } from "lucide-react";
 import { createPortal } from "react-dom";
 
 type DrawerSide = "left" | "right" | "bottom";
 
-interface DrawerProps {
+export interface DrawerProps {
   open: boolean;
   onClose: () => void;
+  /** Accessible title rendered in the default header slot */
   title?: string;
   description?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   side?: DrawerSide;
   size?: "sm" | "md" | "lg" | "full";
   className?: string;
+  /** Replaces the default header entirely */
+  header?: React.ReactNode;
+  /** Rendered below the scrollable body */
   footer?: React.ReactNode;
+  "aria-label"?: string;
 }
 
 const sideStyles: Record<DrawerSide, { base: string; open: string; closed: string }> = {
@@ -31,7 +36,7 @@ const sideStyles: Record<DrawerSide, { base: string; open: string; closed: strin
     closed: "-translate-x-full",
   },
   bottom: {
-    base: "fixed bottom-0 left-0 right-0 border-t border-border",
+    base: "fixed bottom-0 left-0 right-0 border-t border-border rounded-t-2xl",
     open: "translate-y-0",
     closed: "translate-y-full",
   },
@@ -44,13 +49,16 @@ const widthStyles: Record<"sm" | "md" | "lg" | "full", string> = {
   full: "w-full",
 };
 
-function getFocusableElements(container: HTMLElement): HTMLElement[] {
+function getFocusable(container: HTMLElement): HTMLElement[] {
   return Array.from(
     container.querySelectorAll<HTMLElement>(
       'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
     )
   );
 }
+
+/** Minimum swipe distance (px) to trigger close */
+const SWIPE_THRESHOLD = 60;
 
 export function Drawer({
   open,
@@ -61,27 +69,33 @@ export function Drawer({
   side = "right",
   size = "md",
   className,
+  header,
   footer,
+  "aria-label": ariaLabel,
 }: DrawerProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
   const uid = useId();
-  const titleId = `${uid}-drawer-title`;
-  const descId = `${uid}-drawer-desc`;
+  const titleId = `${uid}-title`;
+  const descId = `${uid}-desc`;
   const { base, open: openClass, closed: closedClass } = sideStyles[side];
 
+  // Capture element that had focus before opening
   useEffect(() => {
     if (open) {
       previousFocusRef.current = document.activeElement as HTMLElement;
     }
   }, [open]);
 
+  // Move focus into drawer when it opens
   useEffect(() => {
     if (!open || !panelRef.current) return;
-    const focusable = getFocusableElements(panelRef.current);
+    const focusable = getFocusable(panelRef.current);
     (focusable[0] ?? panelRef.current).focus();
   }, [open]);
 
+  // Restore focus when drawer closes
   useEffect(() => {
     if (!open && previousFocusRef.current) {
       previousFocusRef.current.focus();
@@ -89,31 +103,20 @@ export function Drawer({
     }
   }, [open]);
 
+  // Keyboard: Escape + focus trap
   useEffect(() => {
     if (!open) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-        return;
-      }
+      if (e.key === "Escape") { onClose(); return; }
       if (e.key === "Tab" && panelRef.current) {
-        const focusable = getFocusableElements(panelRef.current);
-        if (focusable.length === 0) {
-          e.preventDefault();
-          return;
-        }
+        const focusable = getFocusable(panelRef.current);
+        if (!focusable.length) { e.preventDefault(); return; }
         const first = focusable[0];
         const last = focusable[focusable.length - 1];
-        if (e.shiftKey) {
-          if (document.activeElement === first) {
-            e.preventDefault();
-            last.focus();
-          }
-        } else {
-          if (document.activeElement === last) {
-            e.preventDefault();
-            first.focus();
-          }
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault(); last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault(); first.focus();
         }
       }
     };
@@ -121,12 +124,37 @@ export function Drawer({
     return () => document.removeEventListener("keydown", handleKey);
   }, [open, onClose]);
 
+  // Body scroll lock
   useEffect(() => {
     document.body.style.overflow = open ? "hidden" : "";
-    return () => {
-      document.body.style.overflow = "";
-    };
+    return () => { document.body.style.overflow = ""; };
   }, [open]);
+
+  // Swipe-to-close (touch events on the panel)
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    const t = e.touches[0];
+    touchStartRef.current = { x: t.clientX, y: t.clientY };
+  }, []);
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (!touchStartRef.current) return;
+    const t = e.changedTouches[0];
+    const dx = t.clientX - touchStartRef.current.x;
+    const dy = t.clientY - touchStartRef.current.y;
+    touchStartRef.current = null;
+
+    const swipeRight = dx > SWIPE_THRESHOLD && Math.abs(dy) < Math.abs(dx);
+    const swipeLeft = dx < -SWIPE_THRESHOLD && Math.abs(dy) < Math.abs(dx);
+    const swipeDown = dy > SWIPE_THRESHOLD && Math.abs(dx) < Math.abs(dy);
+
+    if (
+      (side === "right" && swipeRight) ||
+      (side === "left" && swipeLeft) ||
+      (side === "bottom" && swipeDown)
+    ) {
+      onClose();
+    }
+  }, [side, onClose]);
 
   if (typeof document === "undefined") return null;
 
@@ -145,14 +173,17 @@ export function Drawer({
         aria-hidden="true"
       />
 
-      {/* Drawer panel */}
+      {/* Panel */}
       <div
         ref={panelRef}
         role="dialog"
         aria-modal="true"
+        aria-label={ariaLabel}
         aria-labelledby={title ? titleId : undefined}
         aria-describedby={description ? descId : undefined}
         tabIndex={-1}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
         className={cn(
           base,
           side !== "bottom" ? widthStyles[size] : "max-h-[90dvh]",
@@ -161,37 +192,46 @@ export function Drawer({
           className
         )}
       >
-        {/* Header */}
-        {(title || description) && (
-          <div className="flex-shrink-0 border-b border-border px-6 py-4">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                {title && (
-                  <h2 id={titleId} className="text-lg font-semibold text-text-primary">
-                    {title}
-                  </h2>
-                )}
-                {description && (
-                  <p id={descId} className="mt-0.5 text-sm text-text-secondary">
-                    {description}
-                  </p>
-                )}
-              </div>
-              <button
-                onClick={onClose}
-                className="rounded-lg p-1.5 text-text-muted transition hover:bg-surface-overlay hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                aria-label="Close drawer"
-              >
-                <X className="h-4 w-4" aria-hidden="true" />
-              </button>
-            </div>
+        {/* Bottom drawer drag handle */}
+        {side === "bottom" && (
+          <div className="flex justify-center pt-3 pb-1" aria-hidden="true">
+            <div className="h-1 w-10 rounded-full bg-border" />
           </div>
         )}
 
-        {/* Scrollable content */}
+        {/* Header slot */}
+        {header ?? (
+          (title || description) && (
+            <div className="flex-shrink-0 border-b border-border px-6 py-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  {title && (
+                    <h2 id={titleId} className="text-lg font-semibold text-text-primary">
+                      {title}
+                    </h2>
+                  )}
+                  {description && (
+                    <p id={descId} className="mt-0.5 text-sm text-text-secondary">
+                      {description}
+                    </p>
+                  )}
+                </div>
+                <button
+                  onClick={onClose}
+                  className="rounded-lg p-1.5 text-text-muted transition hover:bg-surface-overlay hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  aria-label="Close drawer"
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
+            </div>
+          )
+        )}
+
+        {/* Body slot */}
         <div className="flex-1 overflow-y-auto px-6 py-4">{children}</div>
 
-        {/* Optional footer */}
+        {/* Footer slot */}
         {footer && (
           <div className="flex-shrink-0 border-t border-border px-6 py-4">{footer}</div>
         )}


### PR DESCRIPTION
mobile drawer with swipe-to-close, focus trap, and header/body/footer slots

- Upgraded ui/drawer.tsx: swipe-to-close via touch events (configurable threshold), optional children, aria-label prop, bottom drawer drag handle visual
- Added MobileNavDrawer component using the drawer with left-side slide-in, full nav links, theme/language/network controls in footer slot
- Refactored Navbar to use MobileNavDrawer instead of inline max-h dropdown


## Related Issues
Closes #231
Closes #230
Closes #226
Closes #222
