### PR TITLE
feat: implement track-swaps page skeleton

### DIFF
--- a/frontend/src/app/swaps/page.tsx
+++ b/frontend/src/app/swaps/page.tsx
@@ -1,77 +1,123 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Card, Badge, Button, EmptyState, Modal, Input } from "@/components/ui";
-import { History, ExternalLink, ArrowRight, Filter } from "lucide-react";
+import { ActivityTimeline, type ActivityTimelineEvent } from "@/components/timeline/ActivityTimeline";
+import { Badge, Button, Card, EmptyState, InlineError } from "@/components/ui";
+import { getExplorerUrl } from "@/lib/explorers";
+import { cn } from "@/lib/utils";
+import { AlertTriangle, ArrowRight, ExternalLink, History, Link2, RefreshCw } from "lucide-react";
 import { SwapStatus } from "@/types";
-import { createDispute } from "@/lib/disputesApi";
 import { useMockSwaps, useSwapHistoryStore } from "@/hooks/useSwapHistory";
 import { useUnifiedWallet } from "@/components/wallet/UnifiedWalletProvider";
 
-export default function HistoryPage() {
+type TimelineStepKey = "initiated" | "source_locked" | "destination_locked" | "settled";
+
+const TIMELINE_STEPS: Array<{ key: TimelineStepKey; label: string; chain: string }> = [
+  { key: "initiated", label: "Swap initiated", chain: "Protocol" },
+  { key: "source_locked", label: "Source lock created", chain: "Source chain" },
+  { key: "destination_locked", label: "Destination lock created", chain: "Destination chain" },
+  { key: "settled", label: "Settlement", chain: "Protocol" },
+];
+
+function getSettledIndex(status: SwapStatus): number {
+  switch (status) {
+    case SwapStatus.PENDING:
+      return 0;
+    case SwapStatus.LOCKED_INITIATOR:
+      return 1;
+    case SwapStatus.LOCKED_RESPONDER:
+      return 2;
+    case SwapStatus.COMPLETED:
+    case SwapStatus.CANCELLED:
+    case SwapStatus.EXPIRED:
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+function buildTimeline(
+  swapId: string,
+  status: SwapStatus,
+  createdAt: string,
+  otherChainTx?: string
+): ActivityTimelineEvent[] {
+  const progress = getSettledIndex(status);
+  const endedInFailure = status === SwapStatus.CANCELLED || status === SwapStatus.EXPIRED;
+
+  return TIMELINE_STEPS.map((step, index) => {
+    let eventStatus: ActivityTimelineEvent["status"] = "pending";
+    if (index < progress) eventStatus = "confirmed";
+    if (index === progress && !endedInFailure) eventStatus = "confirmed";
+    if (index === progress && endedInFailure) eventStatus = "failed";
+
+    const description =
+      index === 3 && status === SwapStatus.COMPLETED
+        ? "Assets were redeemed successfully on both chains."
+        : index === 3 && endedInFailure
+          ? "Swap ended without settlement. Funds can be reclaimed per timelock rules."
+          : "Awaiting next lifecycle confirmation.";
+
+    return {
+      id: `${swapId}-${step.key}`,
+      label: step.label,
+      chain: step.chain,
+      status: eventStatus,
+      timestamp: index <= progress ? createdAt : null,
+      txHash: index >= 1 && otherChainTx ? otherChainTx : undefined,
+      href: index >= 1 && otherChainTx ? getExplorerUrl("ethereum", otherChainTx) : undefined,
+      description,
+    };
+  });
+}
+
+function formatStatusLabel(status: SwapStatus): string {
+  return status.replaceAll("_", " ");
+}
+
+export default function TrackSwapsPage() {
   const { isConnected, activeAddress: address } = useUnifiedWallet();
   const swaps = useSwapHistoryStore((state) => state.swaps);
   const { seedMockSwaps } = useMockSwaps();
 
-  const [open, setOpen] = useState(false);
-  const [selectedSwap, setSelectedSwap] = useState<string>("");
-  const [category, setCategory] = useState("timeout");
-  const [priority, setPriority] = useState("normal");
-  const [reason, setReason] = useState("");
-  const [evidence, setEvidence] = useState("");
-  const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
+  const [selectedSwapId, setSelectedSwapId] = useState<string>("");
 
   useEffect(() => {
     seedMockSwaps();
   }, [seedMockSwaps]);
 
-  const disputableSwaps = useMemo(
-    () =>
-      swaps.filter((swap) => swap.status === SwapStatus.PENDING || swap.status === SwapStatus.EXPIRED),
-    [swaps]
+  useEffect(() => {
+    if (!selectedSwapId && swaps.length > 0) {
+      setSelectedSwapId(swaps[0].id);
+    }
+  }, [selectedSwapId, swaps]);
+
+  const selectedSwap = useMemo(
+    () => swaps.find((swap) => swap.id === selectedSwapId),
+    [selectedSwapId, swaps]
   );
 
-  const submitDispute = async () => {
-    if (!selectedSwap || !reason.trim() || !address) return;
-    setSubmitting(true);
-    setStatusMessage(null);
-    try {
-      await createDispute({
-        swap_id: selectedSwap,
-        submitted_by: address,
-        category: category as any,
-        reason: reason.trim(),
-        priority: priority as any,
-        evidence: evidence.trim() ? [{ type: "note", value: evidence.trim() }] : [],
-      });
-      setStatusMessage("Dispute submitted successfully. Admin review has been queued.");
-      setReason("");
-      setEvidence("");
-      setOpen(false);
-    } catch (err: any) {
-      setStatusMessage(err?.response?.data?.detail ?? "Failed to submit dispute");
-    } finally {
-      setSubmitting(false);
-    }
-  };
+  const timelineEvents = useMemo(() => {
+    if (!selectedSwap) return [];
+    return buildTimeline(selectedSwap.id, selectedSwap.status, selectedSwap.date, selectedSwap.otherChainTx);
+  }, [selectedSwap]);
 
   return (
-    <div className="container mx-auto max-w-4xl px-4 py-12 md:py-20 animate-fade-in">
-      <div className="mb-8 flex items-center justify-between">
+    <div className="container mx-auto max-w-6xl px-4 py-12 md:py-20 animate-fade-in">
+      <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-surface-overlay border border-border font-bold text-text-primary">
             <History className="h-5 w-5" />
           </div>
           <div>
-            <h1 className="text-3xl font-bold text-text-primary">Swap History</h1>
+            <h1 className="text-3xl font-bold text-text-primary">Track Swaps</h1>
             <p className="mt-1 text-sm text-text-secondary">
-              Track and manage your cross-chain atomic swaps.
+              Monitor lifecycle status, timeline events, and transaction links for each swap.
             </p>
           </div>
         </div>
-        <Button variant="secondary" size="sm" icon={<Filter className="h-4 w-4" />}>
-          Filter
+        <Button variant="secondary" size="sm" icon={<RefreshCw className="h-4 w-4" />} onClick={seedMockSwaps}>
+          Refresh
         </Button>
       </div>
 
@@ -83,158 +129,154 @@ export default function HistoryPage() {
           action={{ label: "Open Swap", href: "/swap" }}
         />
       ) : (
-        <div className="space-y-4">
-          {statusMessage && <Card className="p-3 text-sm text-text-secondary">{statusMessage}</Card>}
-
-          {swaps.length === 0 ? (
+        <>
+          {swaps.length === 0 && (
             <EmptyState
               icon={<History className="h-7 w-7" />}
               title="No swaps yet"
               description="You have no historical swaps on this profile. Start with a new cross-chain swap to populate activity here."
               action={{ label: "Start Swap", href: "/swap" }}
             />
-          ) : (
-            swaps.map((swap) => (
-              <Card key={swap.id} hover className="flex items-center justify-between overflow-hidden p-6">
-                <div className="flex items-center gap-6">
-                  <div className="flex -space-x-2">
-                    <div className="h-10 w-10 rounded-full border-2 border-background bg-surface flex items-center justify-center text-xs font-bold">
-                      {swap.from}
-                    </div>
-                    <div className="h-10 w-10 rounded-full border-2 border-background bg-surface flex items-center justify-center text-xs font-bold">
-                      {swap.to}
-                    </div>
-                  </div>
-
-                  <div>
-                    <div className="flex items-center gap-2">
-                      <span className="font-bold text-text-primary">
-                        {swap.amount} {swap.from}
-                      </span>
-                      <ArrowRight className="h-3 w-3 text-text-muted" />
-                      <span className="font-bold text-text-primary">
-                        {swap.toAmount} {swap.to}
-                      </span>
-                    </div>
-                    <p className="text-xs text-text-muted mt-1">
-                      {new Date(swap.date).toLocaleDateString()} at{" "}
-                      {new Date(swap.date).toLocaleTimeString([], {
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })}
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex items-center gap-4">
-                  <Badge status={swap.status} />
-                  <Button variant="ghost" size="sm" className="h-8 w-8 p-0" disabled={!swap.otherChainTx}>
-                    <ExternalLink className="h-4 w-4" />
-                  </Button>
-                  {(swap.status === SwapStatus.PENDING || swap.status === SwapStatus.EXPIRED) && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        setSelectedSwap(swap.id);
-                        setOpen(true);
-                      }}
-                    >
-                      Open Dispute
-                    </Button>
-                  )}
-                </div>
-              </Card>
-            ))
           )}
 
-          {swaps.length > 0 ? (
-            <div className="pt-6 text-center">
-              <p className="text-xs text-text-muted">Showing {swaps.length} recent swaps</p>
+          {swaps.length > 0 && (
+            <div className="grid gap-6 lg:grid-cols-[1.6fr_1fr]">
+              <section className="space-y-6">
+                <Card className="p-5">
+                  <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
+                    Select swap
+                  </label>
+                  <select
+                    value={selectedSwapId}
+                    onChange={(event) => setSelectedSwapId(event.target.value)}
+                    className="w-full rounded-xl border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary"
+                    aria-label="Select swap to track"
+                  >
+                    {swaps.map((swap) => (
+                      <option key={swap.id} value={swap.id}>
+                        {swap.id} · {swap.from} to {swap.to}
+                      </option>
+                    ))}
+                  </select>
+                </Card>
+
+                {!selectedSwap ? (
+                  <InlineError
+                    kind="generic"
+                    error="Unable to load the selected swap details."
+                    onRetry={() => {
+                      if (swaps[0]) setSelectedSwapId(swaps[0].id);
+                    }}
+                  />
+                ) : (
+                  <>
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <Card className="p-5">
+                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
+                          Current status
+                        </p>
+                        <div className="mt-2 flex items-center gap-2">
+                          <Badge status={selectedSwap.status} />
+                          <span className="text-sm capitalize text-text-secondary">
+                            {formatStatusLabel(selectedSwap.status)}
+                          </span>
+                        </div>
+                      </Card>
+                      <Card className="p-5">
+                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
+                          Route
+                        </p>
+                        <div className="mt-2 flex items-center gap-2 font-semibold text-text-primary">
+                          <span>{selectedSwap.from}</span>
+                          <ArrowRight className="h-4 w-4 text-text-muted" />
+                          <span>{selectedSwap.to}</span>
+                        </div>
+                        <p className="mt-2 text-sm text-text-secondary">
+                          {selectedSwap.amount} {selectedSwap.from} to {selectedSwap.toAmount} {selectedSwap.to}
+                        </p>
+                      </Card>
+                    </div>
+
+                    <Card className="p-5">
+                      <ActivityTimeline
+                        title="Status timeline"
+                        events={timelineEvents}
+                        emptyMessage="Timeline data is not available for this swap yet."
+                      />
+                    </Card>
+                  </>
+                )}
+              </section>
+
+              <aside className="space-y-6">
+                <Card className="p-5">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
+                    Event cards
+                  </p>
+                  <div className="mt-4 space-y-3">
+                    {timelineEvents.map((event) => (
+                      <div
+                        key={event.id}
+                        className={cn(
+                          "rounded-xl border p-3",
+                          event.status === "confirmed" && "border-emerald-500/20 bg-emerald-500/5",
+                          event.status === "pending" && "border-border bg-surface-raised",
+                          event.status === "failed" && "border-red-500/20 bg-red-500/5"
+                        )}
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <p className="text-sm font-semibold text-text-primary">{event.label}</p>
+                          <Badge variant={event.status === "failed" ? "error" : event.status === "confirmed" ? "success" : "info"}>
+                            {event.status}
+                          </Badge>
+                        </div>
+                        <p className="mt-1 text-xs text-text-secondary">
+                          {event.timestamp ? new Date(event.timestamp).toLocaleString() : "Waiting for update"}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </Card>
+
+                <Card className="p-5">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
+                    Transaction links
+                  </p>
+                  {!selectedSwap?.otherChainTx ? (
+                    <div className="mt-4 flex items-start gap-2 rounded-xl border border-border bg-surface-raised p-3 text-sm text-text-secondary">
+                      <AlertTriangle className="mt-0.5 h-4 w-4 text-text-muted" />
+                      <p>No external transaction hash is available yet for this swap.</p>
+                    </div>
+                  ) : (
+                    <div className="mt-4 space-y-3">
+                      <a
+                        href={getExplorerUrl("ethereum", selectedSwap.otherChainTx)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center justify-between rounded-xl border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary hover:border-brand-500/40"
+                      >
+                        <span className="inline-flex items-center gap-2">
+                          <Link2 className="h-4 w-4 text-text-muted" />
+                          Destination chain transaction
+                        </span>
+                        <ExternalLink className="h-4 w-4 text-text-muted" />
+                      </a>
+                    </div>
+                  )}
+                </Card>
+
+                <Card className="p-5">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
+                    Tracking context
+                  </p>
+                  <p className="mt-2 text-sm text-text-secondary">Wallet: {address ?? "Not available"}</p>
+                  <p className="mt-1 text-sm text-text-secondary">Swaps in view: {swaps.length}</p>
+                </Card>
+              </aside>
             </div>
-          ) : null}
-        </div>
+          )}
+        </>
       )}
-
-      <Modal
-        open={open}
-        onClose={() => setOpen(false)}
-        title="Submit Swap Dispute"
-        description="Provide evidence and context for manual review."
-      >
-        <div className="flex flex-col gap-3">
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium text-text-secondary">Swap</label>
-            <select
-              value={selectedSwap}
-              onChange={(e) => setSelectedSwap(e.target.value)}
-              className="rounded-xl border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary"
-            >
-              <option value="">Select swap</option>
-              {disputableSwaps.map((swap) => (
-                <option key={swap.id} value={swap.id}>
-                  {swap.id} ({swap.from} to {swap.to})
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium text-text-secondary">Category</label>
-              <select
-                value={category}
-                onChange={(e) => setCategory(e.target.value)}
-                className="rounded-xl border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary"
-              >
-                <option value="timeout">Timeout</option>
-                <option value="incorrect_amount">Incorrect Amount</option>
-                <option value="counterparty_unresponsive">Counterparty Unresponsive</option>
-                <option value="proof_failure">Proof Failure</option>
-                <option value="chain_reorg">Chain Reorg</option>
-                <option value="other">Other</option>
-              </select>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium text-text-secondary">Priority</label>
-              <select
-                value={priority}
-                onChange={(e) => setPriority(e.target.value)}
-                className="rounded-xl border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary"
-              >
-                <option value="low">Low</option>
-                <option value="normal">Normal</option>
-                <option value="high">High</option>
-                <option value="critical">Critical</option>
-              </select>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium text-text-secondary">Reason</label>
-            <textarea
-              value={reason}
-              onChange={(e) => setReason(e.target.value)}
-              className="min-h-[110px] rounded-xl border border-border bg-surface-raised px-3 py-2 text-sm text-text-primary"
-              placeholder="Describe what happened and why manual intervention is needed"
-            />
-          </div>
-
-          <Input
-            label="Evidence (optional)"
-            value={evidence}
-            onChange={(e) => setEvidence(e.target.value)}
-            placeholder="Tx hash, explorer URL, or additional notes"
-          />
-
-          <Button
-            onClick={submitDispute}
-            disabled={submitting || !selectedSwap || reason.trim().length < 10}
-          >
-            {submitting ? "Submitting..." : "Submit Dispute"}
-          </Button>
-        </div>
-      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
Closes #197
Closes #199
Closes #202
Closes #205

## Summary
- implement the track-swaps page skeleton for issue #197
- add a multi-status timeline UI for selected swaps
- add event cards and transaction links area on the tracking view
- define empty and error states for wallet disconnected, no swaps, and invalid selected swap
- keep the implementation scoped to one issue while linking all assigned issues as requested

## Testing
- Not run locally (frontend dependencies are not installed in this clone)