### PR TITLE
feat(frontend): add timeout and retry config to API client

### DIFF
--- a/frontend/src/__tests__/apiClient.test.ts
+++ b/frontend/src/__tests__/apiClient.test.ts
@@ -1,0 +1,56 @@
+import {
+  ApiClientError,
+  DEFAULT_API_RETRY_CONFIG,
+  DEFAULT_API_TIMEOUT_MS,
+  createApiClient,
+  normalizeApiError,
+} from "@/lib/api/client";
+
+describe("createApiClient", () => {
+  it("uses the default timeout when none is provided", () => {
+    const client = createApiClient({ basePath: "/x" });
+    expect(client.instance.defaults.timeout).toBe(DEFAULT_API_TIMEOUT_MS);
+  });
+
+  it("respects an explicit timeoutMs", () => {
+    const client = createApiClient({ basePath: "/x", timeoutMs: 1234 });
+    expect(client.instance.defaults.timeout).toBe(1234);
+  });
+
+  it("merges retry overrides with defaults", () => {
+    const client = createApiClient({
+      basePath: "/x",
+      retry: { maxRetries: 5 },
+    });
+    expect(client.retryConfig).toEqual({
+      ...DEFAULT_API_RETRY_CONFIG,
+      maxRetries: 5,
+    });
+  });
+});
+
+describe("normalizeApiError", () => {
+  it("returns the same instance when given an ApiClientError", () => {
+    const original = new ApiClientError({
+      message: "boom",
+      status: 418,
+      code: "TEAPOT",
+    });
+    expect(normalizeApiError(original)).toBe(original);
+  });
+
+  it("wraps generic Error with UNKNOWN_ERROR code", () => {
+    const wrapped = normalizeApiError(new Error("oops"));
+    expect(wrapped).toBeInstanceOf(ApiClientError);
+    expect(wrapped.code).toBe("UNKNOWN_ERROR");
+    expect(wrapped.status).toBe(500);
+    expect(wrapped.message).toBe("oops");
+  });
+
+  it("wraps unknown values with UNKNOWN_ERROR code", () => {
+    const wrapped = normalizeApiError("string error");
+    expect(wrapped.code).toBe("UNKNOWN_ERROR");
+    expect(wrapped.status).toBe(500);
+    expect(wrapped.details).toBe("string error");
+  });
+});

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -100,14 +100,39 @@ function mergeHeaders(
   };
 }
 
+export const DEFAULT_API_TIMEOUT_MS = 30_000;
+
+export interface ApiRetryConfig {
+  maxRetries: number;
+  initialDelayMs: number;
+  maxDelayMs: number;
+  backoffMultiplier: number;
+}
+
+export const DEFAULT_API_RETRY_CONFIG: ApiRetryConfig = {
+  maxRetries: 0,
+  initialDelayMs: 500,
+  maxDelayMs: 5_000,
+  backoffMultiplier: 2,
+};
+
 export interface ApiClientOptions {
   basePath: string;
   getHeaders?: () => Record<string, string> | undefined;
+  timeoutMs?: number;
+  retry?: Partial<ApiRetryConfig>;
 }
 
-export function createApiClient({ basePath, getHeaders }: ApiClientOptions) {
+export function createApiClient({
+  basePath,
+  getHeaders,
+  timeoutMs = DEFAULT_API_TIMEOUT_MS,
+  retry,
+}: ApiClientOptions) {
+  const retryConfig: ApiRetryConfig = { ...DEFAULT_API_RETRY_CONFIG, ...retry };
   const instance = axios.create({
     baseURL: `${config.api.url}/api/v1${basePath}`,
+    timeout: timeoutMs,
     headers: {
       Accept: "application/json",
     },
@@ -125,6 +150,7 @@ export function createApiClient({ basePath, getHeaders }: ApiClientOptions) {
 
   return {
     instance,
+    retryConfig,
     get: async <T>(url: string = "/", request?: AxiosRequestConfig) => {
       const { data } = await instance.get<T>(url, request);
       return data;

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -1,9 +1,12 @@
 export {
   ApiClientError,
+  DEFAULT_API_RETRY_CONFIG,
+  DEFAULT_API_TIMEOUT_MS,
   createApiClient,
   getUserApiHeaders,
   normalizeApiError,
 } from "./client";
+export type { ApiClientOptions, ApiRetryConfig } from "./client";
 export { cancelOrder, createOrder, getOrder, listOrders, matchOrder } from "./orders";
 export { claimHTLC, createHTLC, getHTLC, getHTLCStatus, listHTLCs, refundHTLC } from "./htlcs";
 export { getSwap, listSwaps, verifySwapProof } from "./swaps";


### PR DESCRIPTION
Closes #215

## Summary
- Adds `DEFAULT_API_TIMEOUT_MS` (30s) applied to every `createApiClient` instance via Axios `timeout`.
- Introduces an `ApiRetryConfig` type and `retry` option on `ApiClientOptions`, merged with `DEFAULT_API_RETRY_CONFIG` and exposed on the returned client as `retryConfig` so callers can read the resolved settings.
- Re-exports the new symbols from `@/lib/api`.

Default behaviour is preserved: existing callers (`htlcs`, `orders`, `swaps`) get the default 30s timeout and `maxRetries: 0`.

## Acceptance criteria
- [x] All frontend calls go through one client (unchanged)
- [x] Error shape is consistent (unchanged: `ApiClientError`)
- [x] Timeout and retry-ready config exists

## Test plan
- [x] `npx jest src/__tests__/apiClient.test.ts` — 6 tests pass covering default + custom timeout, retry merge, and error normalization