### PR TITLE
feat(frontend): add empty-state preset library

### DIFF
--- a/frontend/src/__tests__/emptyStatePresets.test.tsx
+++ b/frontend/src/__tests__/emptyStatePresets.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import {
+  EmptyStates,
+  NoHTLCsEmptyState,
+  NoOrdersEmptyState,
+  NoSearchResultsEmptyState,
+  NoSwapsEmptyState,
+  WalletDisconnectedEmptyState,
+} from "@/components/ui/empty-state-presets";
+
+describe("Empty state presets", () => {
+  it("renders NoSwaps with default CTA", () => {
+    render(<NoSwapsEmptyState />);
+    expect(screen.getByText("No swaps yet")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /start a swap/i })).toHaveAttribute(
+      "href",
+      "/swap"
+    );
+  });
+
+  it("allows overriding the action", () => {
+    render(<NoOrdersEmptyState action={{ label: "Custom CTA", href: "/x" }} />);
+    expect(screen.getByRole("link", { name: /custom cta/i })).toHaveAttribute(
+      "href",
+      "/x"
+    );
+  });
+
+  it("renders NoHTLCs preset", () => {
+    render(<NoHTLCsEmptyState />);
+    expect(screen.getByText("No HTLC activity yet")).toBeInTheDocument();
+  });
+
+  it("renders NoSearchResults without forcing a CTA", () => {
+    render(<NoSearchResultsEmptyState />);
+    expect(screen.getByText("No matching results")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders WalletDisconnected preset", () => {
+    render(<WalletDisconnectedEmptyState />);
+    expect(screen.getByText("Connect your wallet")).toBeInTheDocument();
+  });
+
+  it("exposes a registry under EmptyStates", () => {
+    expect(typeof EmptyStates.NoSwaps).toBe("function");
+    expect(typeof EmptyStates.NoOrders).toBe("function");
+    expect(typeof EmptyStates.NoHTLCs).toBe("function");
+    expect(typeof EmptyStates.NoSearchResults).toBe("function");
+    expect(typeof EmptyStates.WalletDisconnected).toBe("function");
+    expect(typeof EmptyStates.GenericError).toBe("function");
+  });
+});

--- a/frontend/src/components/ui/empty-state-presets.tsx
+++ b/frontend/src/components/ui/empty-state-presets.tsx
@@ -1,0 +1,98 @@
+import { Activity, History, Search, Wallet, Inbox, AlertTriangle } from "lucide-react";
+import { EmptyState } from "./empty-state";
+
+interface EmptyStateAction {
+  label: string;
+  onClick?: () => void;
+  href?: string;
+  variant?: "primary" | "secondary" | "ghost" | "danger" | "outline";
+}
+
+interface PresetProps {
+  action?: EmptyStateAction;
+  secondaryAction?: EmptyStateAction;
+  className?: string;
+}
+
+const ICON_CLASS = "h-7 w-7";
+
+export function NoSwapsEmptyState({ action, ...rest }: PresetProps = {}) {
+  return (
+    <EmptyState
+      icon={<History className={ICON_CLASS} />}
+      title="No swaps yet"
+      description="You have no historical swaps on this profile. Start a new cross-chain swap to populate activity here."
+      action={action ?? { label: "Start a swap", href: "/swap" }}
+      {...rest}
+    />
+  );
+}
+
+export function NoOrdersEmptyState({ action, ...rest }: PresetProps = {}) {
+  return (
+    <EmptyState
+      icon={<Inbox className={ICON_CLASS} />}
+      title="No orders created yet"
+      description="You have not created any orders for this profile. Post your first order from the marketplace."
+      action={action ?? { label: "Browse marketplace", href: "/marketplace" }}
+      {...rest}
+    />
+  );
+}
+
+export function NoHTLCsEmptyState({ action, ...rest }: PresetProps = {}) {
+  return (
+    <EmptyState
+      icon={<Activity className={ICON_CLASS} />}
+      title="No HTLC activity yet"
+      description="No HTLCs are available for the current participant and network context."
+      action={action ?? { label: "Open Swap", href: "/swap" }}
+      {...rest}
+    />
+  );
+}
+
+export function NoSearchResultsEmptyState({ action, ...rest }: PresetProps = {}) {
+  return (
+    <EmptyState
+      icon={<Search className={ICON_CLASS} />}
+      title="No matching results"
+      description="Nothing matches the current filters. Try clearing or broadening the search to see more."
+      action={action}
+      {...rest}
+    />
+  );
+}
+
+export function WalletDisconnectedEmptyState({ action, ...rest }: PresetProps = {}) {
+  return (
+    <EmptyState
+      icon={<Wallet className={ICON_CLASS} />}
+      title="Connect your wallet"
+      description="Connect a wallet to load and monitor activity tied to your account."
+      action={action}
+      {...rest}
+    />
+  );
+}
+
+export function GenericErrorEmptyState({ action, ...rest }: PresetProps = {}) {
+  return (
+    <EmptyState
+      icon={<AlertTriangle className={ICON_CLASS} />}
+      title="Something went wrong"
+      description="We could not load the data for this view. Try again in a moment."
+      action={action ?? { label: "Retry", variant: "secondary" }}
+      {...rest}
+    />
+  );
+}
+
+export const EmptyStates = {
+  NoSwaps: NoSwapsEmptyState,
+  NoOrders: NoOrdersEmptyState,
+  NoHTLCs: NoHTLCsEmptyState,
+  NoSearchResults: NoSearchResultsEmptyState,
+  WalletDisconnected: WalletDisconnectedEmptyState,
+  GenericError: GenericErrorEmptyState,
+} as const;

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -15,6 +15,15 @@ export { ExplorerLink } from "./ExplorerLink";
 export { ChainIcon } from "./ChainIcon";
 export { TokenIcon } from "./TokenIcon";
 export { EmptyState } from "./empty-state";
+export {
+  EmptyStates,
+  NoSwapsEmptyState,
+  NoOrdersEmptyState,
+  NoHTLCsEmptyState,
+  NoSearchResultsEmptyState,
+  WalletDisconnectedEmptyState,
+  GenericErrorEmptyState,
+} from "./empty-state-presets";
 export { PaginationControls } from "./PaginationControls";
 export { DataTable } from "./data-table";
 export type { ColumnDef } from "./data-table";


### PR DESCRIPTION
Closes #218

## Summary
Adds a small library of standardized empty-state presets on top of the existing `EmptyState` primitive so pages share consistent copy, iconography, and CTA patterns.

Presets added (under `@/components/ui`):
- `NoSwapsEmptyState` (default CTA: Start a swap → /swap)
- `NoOrdersEmptyState` (default CTA: Browse marketplace → /marketplace)
- `NoHTLCsEmptyState` (default CTA: Open Swap → /swap)
- `NoSearchResultsEmptyState` (no default CTA — designed for filter/search empty states)
- `WalletDisconnectedEmptyState`
- `GenericErrorEmptyState` (default CTA: Retry, secondary variant)

Also exposes an `EmptyStates` registry for ergonomic reference (`<EmptyStates.NoSwaps />`).

## Acceptance criteria
- [x] Empty states are reusable across pages
- [x] Copy follows consistent tone
- [x] Supports optional CTA button (each preset accepts `action` / `secondaryAction` overrides)

## Test plan
- [x] `npx jest src/__tests__/emptyStatePresets.test.tsx` — 6 tests pass