### PR TITLE
feat(frontend): add websocket readiness placeholder for swap events

### DIFF
--- a/frontend/src/__tests__/swapEvents.test.ts
+++ b/frontend/src/__tests__/swapEvents.test.ts
@@ -1,0 +1,93 @@
+import {
+  createPollingTransport,
+  createWebsocketTransportPlaceholder,
+  resolveSwapEventTransport,
+  type SwapEvent,
+} from "@/lib/swapEvents";
+
+describe("createPollingTransport", () => {
+  it("delivers fetched events to the listener", async () => {
+    jest.useFakeTimers();
+    const event: SwapEvent = {
+      type: "swap.status_changed",
+      swapId: "abc",
+      timestamp: "2026-01-01T00:00:00Z",
+    };
+    const fetchEvents = jest.fn().mockResolvedValue([event]);
+    const transport = createPollingTransport(fetchEvents, 1_000);
+    const listener = jest.fn();
+
+    const unsubscribe = transport.subscribe(listener);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchEvents).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(event);
+
+    unsubscribe();
+    jest.advanceTimersByTime(5_000);
+    expect(fetchEvents).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it("swallows fetch errors so polling stays alive", async () => {
+    jest.useFakeTimers();
+    const fetchEvents = jest.fn().mockRejectedValue(new Error("network down"));
+    const transport = createPollingTransport(fetchEvents, 1_000);
+    const listener = jest.fn();
+    const unsubscribe = transport.subscribe(listener);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
+    jest.useRealTimers();
+  });
+});
+
+describe("createWebsocketTransportPlaceholder", () => {
+  it("is a no-op until the backend exposes events", () => {
+    const transport = createWebsocketTransportPlaceholder();
+    expect(transport.name).toBe("websocket");
+    const listener = jest.fn();
+    const unsubscribe = transport.subscribe(listener);
+    expect(typeof unsubscribe).toBe("function");
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+});
+
+describe("resolveSwapEventTransport", () => {
+  it("returns polling by default", () => {
+    const transport = resolveSwapEventTransport({
+      websocketEnabled: false,
+      options: { fetchEvents: async () => [] },
+    });
+    expect(transport.name).toBe("polling");
+  });
+
+  it("returns polling when feature flag is on but preferWebsocket is false", () => {
+    const transport = resolveSwapEventTransport({
+      websocketEnabled: true,
+      options: { fetchEvents: async () => [], preferWebsocket: false },
+    });
+    expect(transport.name).toBe("polling");
+  });
+
+  it("returns websocket when feature flag is on and preferWebsocket is true", () => {
+    const transport = resolveSwapEventTransport({
+      websocketEnabled: true,
+      options: { preferWebsocket: true, fetchEvents: async () => [] },
+    });
+    expect(transport.name).toBe("websocket");
+  });
+
+  it("throws when polling is active but no fetchEvents provided", () => {
+    expect(() =>
+      resolveSwapEventTransport({
+        websocketEnabled: false,
+        options: {},
+      })
+    ).toThrow(/fetchEvents is required/);
+  });
+});

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -46,6 +46,8 @@ export const config = {
   features: {
     ordersEnabled: getEnv("NEXT_PUBLIC_FEATURE_ORDERS_ENABLED", "true") === "true",
     swapsEnabled: getEnv("NEXT_PUBLIC_FEATURE_SWAPS_ENABLED", "true") === "true",
+    swapWebsocketEnabled:
+      getEnv("NEXT_PUBLIC_FEATURE_SWAP_WS_ENABLED", "false") === "true",
   },
 } as const;
 

--- a/frontend/src/lib/swapEvents.ts
+++ b/frontend/src/lib/swapEvents.ts
@@ -1,0 +1,121 @@
+/**
+ * Swap event abstraction.
+ *
+ * Provides a single, typed integration point for "swap update" notifications
+ * so call sites do not need to know whether the underlying transport is a
+ * websocket or a polling loop. Default behaviour is polling. The websocket
+ * transport is gated behind the NEXT_PUBLIC_FEATURE_SWAP_WS_ENABLED feature
+ * flag (see lib/config.ts) and remains a placeholder until the backend
+ * pushes real-time swap events.
+ */
+
+export type SwapEventType =
+  | "swap.created"
+  | "swap.status_changed"
+  | "swap.locked_initiator"
+  | "swap.locked_responder"
+  | "swap.completed"
+  | "swap.refunded"
+  | "swap.expired";
+
+export interface SwapEvent<T = unknown> {
+  type: SwapEventType;
+  swapId: string;
+  timestamp: string;
+  data?: T;
+}
+
+export type SwapEventListener = (event: SwapEvent) => void;
+
+export interface SwapEventTransport {
+  /** Identifier shown in dev tools / logs. */
+  readonly name: "polling" | "websocket";
+  /** Subscribe to a stream of swap events. Returns an unsubscribe fn. */
+  subscribe(listener: SwapEventListener): () => void;
+}
+
+export interface SwapEventOptions {
+  /**
+   * If true, prefer the websocket transport when the feature flag is on and
+   * the runtime supports it. Falls back to polling otherwise.
+   */
+  preferWebsocket?: boolean;
+  /** Polling interval in ms (default 15s). */
+  pollIntervalMs?: number;
+  /**
+   * Function that fetches the latest events to feed into the polling
+   * transport. Required when polling is used.
+   */
+  fetchEvents?: () => Promise<SwapEvent[]>;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 15_000;
+
+export function createPollingTransport(
+  fetchEvents: () => Promise<SwapEvent[]>,
+  intervalMs: number = DEFAULT_POLL_INTERVAL_MS
+): SwapEventTransport {
+  return {
+    name: "polling",
+    subscribe(listener) {
+      let cancelled = false;
+      const tick = async () => {
+        if (cancelled) return;
+        try {
+          const events = await fetchEvents();
+          if (cancelled) return;
+          for (const event of events) {
+            listener(event);
+          }
+        } catch {
+          // Swallow polling errors; a future event will drive recovery.
+        }
+      };
+
+      void tick();
+      const handle = setInterval(tick, intervalMs);
+
+      return () => {
+        cancelled = true;
+        clearInterval(handle);
+      };
+    },
+  };
+}
+
+/**
+ * Placeholder websocket transport. The real implementation will wire into
+ * the existing `useWebSocket` hook once the backend exposes the
+ * `swap_events` channel. Until then this transport is a no-op so that
+ * enabling the feature flag is safe.
+ */
+export function createWebsocketTransportPlaceholder(): SwapEventTransport {
+  return {
+    name: "websocket",
+    subscribe() {
+      return () => {};
+    },
+  };
+}
+
+export interface ResolveTransportArgs {
+  websocketEnabled: boolean;
+  options: SwapEventOptions;
+}
+
+export function resolveSwapEventTransport({
+  websocketEnabled,
+  options,
+}: ResolveTransportArgs): SwapEventTransport {
+  if (websocketEnabled && options.preferWebsocket) {
+    return createWebsocketTransportPlaceholder();
+  }
+
+  if (!options.fetchEvents) {
+    throw new Error(
+      "resolveSwapEventTransport: fetchEvents is required when polling is the active transport"
+    );
+  }
+
+  return createPollingTransport(options.fetchEvents, options.pollIntervalMs);
+}


### PR DESCRIPTION
Closes #227

## Summary
Adds a typed swap-event abstraction so the rest of the app can subscribe to swap updates without caring about the underlying transport.

- `SwapEvent` / `SwapEventType` document the event surface in code.
- `createPollingTransport` is the default transport (15s default interval, configurable).
- `createWebsocketTransportPlaceholder` is a no-op stub that the existing `useWebSocket` hook will plug into once the backend exposes a `swap_events` channel.
- `resolveSwapEventTransport({ websocketEnabled, options })` chooses between transports — polling unless the feature flag is on **and** the caller opts in via `preferWebsocket: true`.
- New feature flag: `NEXT_PUBLIC_FEATURE_SWAP_WS_ENABLED` (`config.features.swapWebsocketEnabled`), defaults off.

## Acceptance criteria
- [x] Event interface is documented in code (`SwapEvent`, `SwapEventTransport`)
- [x] Polling remains default behaviour
- [x] Integration can be toggled via feature flag

## Test plan
- [x] `npx jest src/__tests__/swapEvents.test.ts` — 7 tests pass covering polling delivery, error swallowing, websocket placeholder, and resolver fallbacks