### PR TITLE
feat(frontend): Add skeleton components, URL-synced pagination, and retry strategy

### DIFF
--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -5,7 +5,7 @@ export { Input } from "./input";
 export { Select } from "./select";
 export { Modal } from "./modal";
 export { Drawer } from "./drawer";
-export { Spinner, LoadingState, Skeleton } from "./spinner";
+export { Spinner, LoadingState, Skeleton, CardSkeleton, ListItemSkeleton, FormSkeleton, TimelineItemSkeleton, StatCardSkeleton, TableRowSkeleton, AvatarSkeleton, BadgeSkeleton } from "./spinner";
 export { Toast, ToastContainer } from "./toast";
 export type { ToastType } from "./toast";
 export { ToastProvider } from "./ToastProvider";

--- a/frontend/src/components/ui/spinner.tsx
+++ b/frontend/src/components/ui/spinner.tsx
@@ -50,3 +50,94 @@ export function LoadingState({ label = "Loading…", size = "md", className }: L
 export function Skeleton({ className }: { className?: string }) {
   return <div className={cn("animate-pulse rounded-lg bg-surface-overlay", className)} />;
 }
+
+/** Card skeleton placeholder */
+export function CardSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("rounded-2xl border border-border bg-surface-raised p-5", className)}>
+      <div className="space-y-3">
+        <Skeleton className="h-4 w-1/3" />
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-2/3" />
+      </div>
+    </div>
+  );
+}
+
+/** List item skeleton placeholder */
+export function ListItemSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex items-center gap-4 rounded-2xl border border-border bg-surface-raised p-4", className)}>
+      <Skeleton className="h-10 w-10 rounded-full shrink-0" />
+      <div className="flex-1 space-y-2 min-w-0">
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-3 w-1/2" />
+      </div>
+      <Skeleton className="h-8 w-20 rounded-xl shrink-0" />
+    </div>
+  );
+}
+
+/** Form skeleton placeholder */
+export function FormSkeleton({ rows = 3, className }: { rows?: number; className?: string }) {
+  return (
+    <div className={cn("space-y-4", className)}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="space-y-2">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Timeline event skeleton placeholder */
+export function TimelineItemSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex gap-4", className)}>
+      <div className="flex flex-col items-center">
+        <Skeleton className="h-6 w-6 rounded-full" />
+        <Skeleton className="w-0.5 flex-1" />
+      </div>
+      <div className="flex-1 space-y-2 pb-6">
+        <Skeleton className="h-4 w-1/2" />
+        <Skeleton className="h-3 w-3/4" />
+      </div>
+    </div>
+  );
+}
+
+/** Stat card skeleton placeholder */
+export function StatCardSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("rounded-2xl border border-border bg-surface-overlay/40 p-4", className)}>
+      <Skeleton className="h-3 w-20 mb-3" />
+      <Skeleton className="h-8 w-16" />
+    </div>
+  );
+}
+
+/** Table row skeleton placeholder */
+export function TableRowSkeleton({ cols = 5, className }: { cols?: number; className?: string }) {
+  return (
+    <tr className={cn("border-b border-border", className)}>
+      {Array.from({ length: cols }).map((_, i) => (
+        <td key={i} className="px-4 py-3">
+          <Skeleton className="h-4 w-full" />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+/** Avatar skeleton placeholder */
+export function AvatarSkeleton({ size = "md", className }: { size?: "sm" | "md" | "lg"; className?: string }) {
+  const sizeStyles = { sm: "h-8 w-8", md: "h-10 w-10", lg: "h-14 w-14" };
+  return <Skeleton className={cn("rounded-full", sizeStyles[size], className)} />;
+}
+
+/** Badge skeleton placeholder */
+export function BadgeSkeleton({ className }: { className?: string }) {
+  return <Skeleton className={cn("h-6 w-20 rounded-full", className)} />;
+}

--- a/frontend/src/hooks/usePaginationWithURL.ts
+++ b/frontend/src/hooks/usePaginationWithURL.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useCallback, useMemo, useEffect } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { usePagination } from "./usePagination";
+
+const DEFAULT_PAGE_PARAM = "page";
+
+export function usePaginationWithURL(
+  totalItems: number,
+  pageSize: number,
+  options: {
+    paramName?: string;
+    initialPage?: number;
+    onPageChange?: (page: number) => void;
+  } = {}
+) {
+  const { paramName = DEFAULT_PAGE_PARAM, initialPage = 1, onPageChange } = options;
+
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const pageParam = searchParams.get(paramName);
+  const pageFromUrl = pageParam ? parseInt(pageParam, 10) : initialPage;
+  const safePageFromUrl = Number.isFinite(pageFromUrl) && pageFromUrl > 0 ? pageFromUrl : initialPage;
+
+  const pagination = usePagination(totalItems, pageSize, safePageFromUrl);
+
+  useEffect(() => {
+    if (pagination.page !== safePageFromUrl) {
+      pagination.setPage(safePageFromUrl);
+    }
+  }, [pagination, safePageFromUrl]);
+
+  const setPage = useCallback(
+    (page: number) => {
+      pagination.setPage(page);
+      onPageChange?.(page);
+    },
+    [pagination, onPageChange]
+  );
+
+  const pushPageToUrl = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (page === initialPage) {
+        params.delete(paramName);
+      } else {
+        params.set(paramName, String(page));
+      }
+      const queryString = params.toString();
+      router.push(`${pathname}${queryString ? `?${queryString}` : ""}`, { scroll: false });
+    },
+    [initialPage, paramName, pathname, router, searchParams]
+  );
+
+  const setPageAndSync = useCallback(
+    (page: number) => {
+      setPage(page);
+      pushPageToUrl(page);
+    },
+    [setPage, pushPageToUrl]
+  );
+
+  const reset = useCallback(() => {
+    pagination.reset();
+    pushPageToUrl(initialPage);
+  }, [pagination, pushPageToUrl, initialPage]);
+
+  const controls = useMemo(
+    () => ({
+      ...pagination,
+      setPage,
+      setPageAndSync,
+      reset,
+      pushPageToUrl,
+    }),
+    [pagination, setPage, setPageAndSync, reset, pushPageToUrl]
+  );
+
+  return controls;
+}

--- a/frontend/src/hooks/useRequestRetry.ts
+++ b/frontend/src/hooks/useRequestRetry.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import axios, { AxiosError, AxiosRequestConfig } from "axios";
+
+export const IDEMPOTENT_METHODS = ["GET", "HEAD", "OPTIONS"];
+
+export interface RetryOptions {
+  maxRetries?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  backoffMultiplier?: number;
+  onRetry?: (attempt: number, error: AxiosError, delayMs: number) => void;
+  onMaxRetriesExceeded?: (error: AxiosError) => void;
+}
+
+export interface RequestOptions extends RetryOptions {
+  silent?: boolean;
+}
+
+function calculateBackoff(delay: number, multiplier: number, jitter: number, maxDelay: number): number {
+  const next = Math.min(delay * multiplier, maxDelay);
+  return Math.round(next + jitter * next);
+}
+
+export function useRequestRetry() {
+  const abortControllersRef = useRef<Map<string, AbortController>>(new Map());
+
+  const isIdempotent = useCallback((method?: string): boolean => {
+    return IDEMPOTENT_METHODS.includes((method ?? "").toUpperCase());
+  }, []);
+
+  const requestWithRetry = useCallback(
+    async <T>(
+      config: AxiosRequestConfig,
+      options: RequestOptions = {}
+    ): Promise<T> => {
+      const {
+        maxRetries = 3,
+        initialDelayMs = 1000,
+        maxDelayMs = 30000,
+        backoffMultiplier = 2,
+        onRetry,
+        onMaxRetriesExceeded,
+        silent = false,
+      } = options;
+
+      let attempt = 0;
+      let delayMs = initialDelayMs;
+      let lastError: AxiosError | undefined;
+
+      while (attempt <= maxRetries) {
+        try {
+          const response = await axios.request<T>({ ...config });
+          return response.data;
+        } catch (error) {
+          if (!axios.isAxiosError(error)) {
+            throw error;
+          }
+
+          lastError = error as AxiosError;
+
+          if (attempt === maxRetries) {
+            if (!silent) {
+              console.error(`[RequestRetry] Max retries (${maxRetries}) exceeded:`, error);
+            }
+            onMaxRetriesExceeded?.(lastError);
+            throw error;
+          }
+
+          const isServerError = (error.response?.status ?? 0) >= 500;
+          const isNetworkError = !error.response;
+          const isTimeout = axios.isAxiosError(error) && error.code === "ECONNABORTED";
+
+          if (!isServerError && !isNetworkError && !isTimeout) {
+            if (!silent) {
+              console.warn(`[RequestRetry] Non-retryable error (${error.response?.status}):`, error.message);
+            }
+            throw error;
+          }
+
+          const jitter = Math.random() * 0.2;
+          onRetry?.(attempt + 1, lastError, delayMs);
+
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          delayMs = calculateBackoff(delayMs, backoffMultiplier, jitter, maxDelayMs);
+          attempt++;
+        }
+      }
+
+      throw lastError;
+    },
+    []
+  );
+
+  const abortAll = useCallback(() => {
+    abortControllersRef.current.forEach((controller) => controller.abort());
+    abortControllersRef.current.clear();
+  }, []);
+
+  const abort = useCallback((key: string) => {
+    const controller = abortControllersRef.current.get(key);
+    if (controller) {
+      controller.abort();
+      abortControllersRef.current.delete(key);
+    }
+  }, []);
+
+  const trackedRequest = useCallback(
+    async <T>(
+      key: string,
+      config: AxiosRequestConfig,
+      options: RequestOptions = {}
+    ): Promise<T> => {
+      const controller = new AbortController();
+      abortControllersRef.current.set(key, controller);
+      try {
+        return await requestWithRetry<T>({ ...config, signal: controller.signal }, options);
+      } finally {
+        abortControllersRef.current.delete(key);
+      }
+    },
+    [requestWithRetry]
+  );
+
+  return { requestWithRetry, trackedRequest, isIdempotent, abortAll, abort };
+}
+
+export function isRetryableError(error: unknown): boolean {
+  if (!axios.isAxiosError(error)) return false;
+  const status = error.response?.status ?? 0;
+  return status >= 500 || status === 0 || error.code === "ECONNABORTED";
+}

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,14 +1,29 @@
 import { QueryClient } from "@tanstack/react-query";
 
+function isRetryableError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const status = (error as { response?: { status?: number }; code?: string }).response?.status;
+  if (status === undefined) return true;
+  return status >= 500;
+}
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 30_000,
-      retry: 2,
       refetchOnWindowFocus: false,
+      retry: (failureCount, error) => {
+        if (failureCount > 3) return false;
+        return isRetryableError(error);
+      },
+      retryDelay: (attemptIndex: number) => Math.min(1000 * Math.pow(2, attemptIndex), 30000),
     },
     mutations: {
-      retry: 1,
+      retry: (failureCount, error) => {
+        if (failureCount > 2) return false;
+        return isRetryableError(error);
+      },
+      retryDelay: (attemptIndex: number) => Math.min(1000 * Math.pow(2, attemptIndex), 30000),
     },
   },
 });

--- a/frontend/src/stories/Skeleton.stories.tsx
+++ b/frontend/src/stories/Skeleton.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CardSkeleton, ListItemSkeleton, FormSkeleton, TimelineItemSkeleton, StatCardSkeleton, TableRowSkeleton, AvatarSkeleton, BadgeSkeleton, Skeleton } from "@/components/ui/spinner";
+
+const meta = {
+  title: "UI/Skeletons",
+  component: Skeleton,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+
+export const Base: StoryObj = {
+  render: () => <Skeleton className="h-4 w-full" />,
+};
+
+export const CardSkeletonStory: StoryObj = {
+  render: () => <CardSkeleton className="max-w-md" />,
+};
+
+export const ListItemSkeletonStory: StoryObj = {
+  render: () => <ListItemSkeleton className="max-w-md" />,
+};
+
+export const FormSkeletonStory: StoryObj = {
+  render: () => <FormSkeleton rows={4} className="max-w-sm" />,
+};
+
+export const TimelineItemSkeletonStory: StoryObj = {
+  render: () => <TimelineItemSkeleton className="max-w-sm" />,
+};
+
+export const StatCardSkeletonStory: StoryObj = {
+  render: () => (
+    <div className="grid grid-cols-3 gap-4 max-w-md">
+      <StatCardSkeleton />
+      <StatCardSkeleton />
+      <StatCardSkeleton />
+    </div>
+  ),
+};
+
+export const TableRowSkeletonStory: StoryObj = {
+  render: () => (
+    <table className="w-full max-w-md">
+      <tbody>
+        <TableRowSkeleton cols={4} />
+        <TableRowSkeleton cols={4} />
+        <TableRowSkeleton cols={4} />
+      </tbody>
+    </table>
+  ),
+};
+
+export const AvatarSkeletonStory: StoryObj = {
+  render: () => (
+    <div className="flex gap-4">
+      <AvatarSkeleton size="sm" />
+      <AvatarSkeleton size="md" />
+      <AvatarSkeleton size="lg" />
+    </div>
+  ),
+};
+
+export const BadgeSkeletonStory: StoryObj = {
+  render: () => (
+    <div className="flex gap-2">
+      <BadgeSkeleton />
+      <BadgeSkeleton className="w-28" />
+      <BadgeSkeleton className="w-36" />
+    </div>
+  ),
+};
+
+export const AllSkeletons: StoryObj = {
+  render: () => (
+    <div className="space-y-8 p-8 max-w-2xl">
+      <section>
+        <h3 className="text-sm font-semibold mb-2 text-text-muted uppercase tracking-wide">Cards</h3>
+        <CardSkeleton />
+      </section>
+      <section>
+        <h3 className="text-sm font-semibold mb-2 text-text-muted uppercase tracking-wide">List Items</h3>
+        <div className="space-y-2">
+          <ListItemSkeleton />
+          <ListItemSkeleton />
+        </div>
+      </section>
+      <section>
+        <h3 className="text-sm font-semibold mb-2 text-text-muted uppercase tracking-wide">Form Fields</h3>
+        <FormSkeleton rows={3} />
+      </section>
+      <section>
+        <h3 className="text-sm font-semibold mb-2 text-text-muted uppercase tracking-wide">Timeline</h3>
+        <div className="space-y-0">
+          <TimelineItemSkeleton />
+          <TimelineItemSkeleton />
+        </div>
+      </section>
+      <section>
+        <h3 className="text-sm font-semibold mb-2 text-text-muted uppercase tracking-wide">Stat Cards</h3>
+        <div className="grid grid-cols-3 gap-4">
+          <StatCardSkeleton />
+          <StatCardSkeleton />
+          <StatCardSkeleton />
+        </div>
+      </section>
+      <section>
+        <h3 className="text-sm font-semibold mb-2 text-text-muted uppercase tracking-wide">Table Rows</h3>
+        <table className="w-full">
+          <tbody>
+            <TableRowSkeleton cols={4} />
+            <TableRowSkeleton cols={4} />
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h3 className="text-sm font-semibold mb-2 text-text-muted uppercase tracking-wide">Avatars</h3>
+        <div className="flex items-center gap-4">
+          <AvatarSkeleton size="sm" />
+          <AvatarSkeleton size="md" />
+          <AvatarSkeleton size="lg" />
+        </div>
+      </section>
+      <section>
+        <h3 className="text-sm font-semibold mb-2 text-text-muted uppercase tracking-wide">Badges</h3>
+        <div className="flex flex-wrap gap-2">
+          <BadgeSkeleton />
+          <BadgeSkeleton />
+          <BadgeSkeleton className="w-28" />
+        </div>
+      </section>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary
- Expand skeleton library with CardSkeleton, ListItemSkeleton, FormSkeleton, TimelineItemSkeleton, StatCardSkeleton, TableRowSkeleton, AvatarSkeleton, BadgeSkeleton
- Add usePaginationWithURL hook for page state synced with URL parameters
- Add useRequestRetry hook for axios retry with exponential backoff
- Configure react-query with configurable retry and exponential backoff
- Add Storybook stories for all skeleton components

## Changes
- `frontend/src/components/ui/spinner.tsx` - Added 9 new skeleton components
- `frontend/src/components/ui/index.ts` - Exported new skeleton components
- `frontend/src/hooks/usePaginationWithURL.ts` - New hook for URL-synced pagination
- `frontend/src/hooks/useRequestRetry.ts` - New hook for axios retry with backoff
- `frontend/src/lib/queryClient.ts` - Enhanced retry config with exponential backoff
- `frontend/src/stories/Skeleton.stories.tsx` - Storybook documentation

Closes #229
Closes #217
Closes #223
Closes #221