### PR TITLE
feat(frontend): build reusable order list table

### DIFF
--- a/frontend/src/components/marketplace/OrderBookList.tsx
+++ b/frontend/src/components/marketplace/OrderBookList.tsx
@@ -4,9 +4,10 @@ import { useMemo, useState, useEffect } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Order, OrderSide, OrderStatus } from "@/types";
 import { Badge, Button, Modal } from "@/components/ui";
-import { ArrowUpDown, Filter, Search, Zap, Eye, X } from "lucide-react";
+import { Search, Zap, X } from "lucide-react";
 import { clsx } from "clsx";
 import { useUnifiedWallet } from "@/components/wallet/UnifiedWalletProvider";
+import { OrderListTable, OrderSortKey } from "@/components/marketplace/OrderListTable";
 
 interface OrderBookListProps {
   orders: Order[];
@@ -95,7 +96,7 @@ export function OrderBookList({ orders, onTakeOrder }: OrderBookListProps) {
   const [assetFilter, setAssetFilter] = useState(() => searchParams.get("asset") ?? "all");
   const [detailsOrder, setDetailsOrder] = useState<Order | null>(null);
   const [sortConfig, setSortConfig] = useState<{
-    key: "price" | "amount" | "timestamp";
+    key: OrderSortKey;
     direction: "asc" | "desc";
   }>({ key: "timestamp", direction: "desc" });
 
@@ -140,10 +141,6 @@ export function OrderBookList({ orders, onTakeOrder }: OrderBookListProps) {
     setAssetFilter(searchParams.get("asset") ?? "all");
   }, [searchParams]);
 
-  function parseNumericValue(value: string) {
-    return Number(value.replace(/,/g, "")) || 0;
-  }
-
   const filteredOrders = useMemo(() => {
     return orders
       .filter((o) => {
@@ -166,32 +163,14 @@ export function OrderBookList({ orders, onTakeOrder }: OrderBookListProps) {
           o.status === OrderStatus.OPEN &&
           notExpired
         );
-      })
-      .sort((a, b) => {
-        const direction = sortConfig.direction === "asc" ? 1 : -1;
-
-        if (sortConfig.key === "timestamp") {
-          return (
-            (new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()) * direction
-          );
-        }
-
-        if (sortConfig.key === "price") {
-          return (parseNumericValue(a.price) - parseNumericValue(b.price)) * direction;
-        }
-
-        return (parseNumericValue(a.amount) - parseNumericValue(b.amount)) * direction;
       });
-  }, [assetFilter, chainPairFilter, orders, search, sideFilter, sortConfig]);
+  }, [assetFilter, chainPairFilter, orders, search, sideFilter]);
 
-  const handleSort = (key: "price" | "amount" | "timestamp") => {
-    let direction: "asc" | "desc" = "desc";
-    if (sortConfig.key === key && sortConfig.direction === "desc") {
-      direction = "asc";
-    } else if (sortConfig.key === key && sortConfig.direction === "asc") {
-      direction = "desc";
-    }
-    setSortConfig({ key, direction });
+  const handleSort = (key: OrderSortKey) => {
+    setSortConfig((current) => {
+      if (current.key !== key) return { key, direction: "desc" };
+      return { key, direction: current.direction === "desc" ? "asc" : "desc" };
+    });
   };
 
   const resetFilters = () => {
@@ -241,6 +220,7 @@ export function OrderBookList({ orders, onTakeOrder }: OrderBookListProps) {
             Sells
           </Button>
           <select
+            aria-label="Filter by chain route"
             value={chainPairFilter}
             onChange={(event) => setChainPairFilter(event.target.value)}
             className="h-8 rounded-xl border border-border bg-surface-raised px-3 text-xs text-text-primary"
@@ -253,6 +233,7 @@ export function OrderBookList({ orders, onTakeOrder }: OrderBookListProps) {
             ))}
           </select>
           <select
+            aria-label="Filter by asset"
             value={assetFilter}
             onChange={(event) => setAssetFilter(event.target.value)}
             className="h-8 rounded-xl border border-border bg-surface-raised px-3 text-xs text-text-primary"
@@ -278,130 +259,18 @@ export function OrderBookList({ orders, onTakeOrder }: OrderBookListProps) {
         </div>
       </div>
 
-      <div className="rounded-2xl border border-border bg-background/50 overflow-hidden backdrop-blur-sm shadow-xl">
-        <div className="overflow-x-auto">
-          <table className="w-full text-left border-collapse">
-            <thead>
-              <tr className="bg-surface-overlay/50 border-b border-border">
-                <th className="px-6 py-4 text-xs font-bold uppercase tracking-wider text-text-muted">
-                  Pair
-                </th>
-                <th className="px-6 py-4 text-xs font-bold uppercase tracking-wider text-text-muted">
-                  Side
-                </th>
-                <th
-                  className="px-6 py-4 text-xs font-bold uppercase tracking-wider text-text-muted cursor-pointer hover:text-text-primary"
-                  onClick={() => handleSort("amount")}
-                >
-                  <div className="flex items-center gap-2">
-                    Amount <ArrowUpDown size={12} />
-                  </div>
-                </th>
-                <th
-                  className="px-6 py-4 text-xs font-bold uppercase tracking-wider text-text-muted cursor-pointer hover:text-text-primary"
-                  onClick={() => handleSort("price")}
-                >
-                  <div className="flex items-center gap-2">
-                    Price <ArrowUpDown size={12} />
-                  </div>
-                </th>
-                <th
-                  className="px-6 py-4 text-xs font-bold uppercase tracking-wider text-text-muted cursor-pointer hover:text-text-primary"
-                  onClick={() => handleSort("timestamp")}
-                >
-                  <div className="flex items-center gap-2">
-                    Created <ArrowUpDown size={12} />
-                  </div>
-                </th>
-                <th className="px-6 py-4 text-xs font-bold uppercase tracking-wider text-text-muted">
-                  Total
-                </th>
-                <th className="px-4 py-4"></th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/50">
-              {filteredOrders.length > 0 ? (
-                filteredOrders.map((order) => (
-                  <tr
-                    key={order.id}
-                    className="group hover:bg-surface-overlay/30 transition-colors"
-                  >
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="flex flex-col">
-                        <span className="font-bold text-text-primary">{order.pair}</span>
-                        <span className="text-[10px] text-text-muted uppercase tracking-tighter">
-                          {order.chainIn} ↔ {order.chainOut}
-                        </span>
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <Badge variant={order.side === OrderSide.BUY ? "success" : "error"}>
-                        {order.side.toUpperCase()}
-                      </Badge>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap font-mono text-sm text-text-primary">
-                      {order.amount} {order.tokenIn}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap font-mono text-sm text-text-secondary">
-                      {order.price}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-xs text-text-secondary">
-                      {new Date(order.timestamp).toLocaleString([], {
-                        dateStyle: "short",
-                        timeStyle: "short",
-                      })}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap font-mono text-sm font-bold text-text-primary">
-                      {order.total} {order.tokenOut}
-                    </td>
-                    <td className="px-4 py-4 text-right">
-                      <div className="flex justify-end gap-2">
-                        <Button
-                          variant="secondary"
-                          size="sm"
-                          onClick={() => setDetailsOrder(order)}
-                          icon={<Eye size={14} />}
-                        >
-                          Details
-                        </Button>
-                        <Button
-                          variant="primary"
-                          size="sm"
-                          className="shadow-glow-sm hover:shadow-glow-md"
-                          onClick={() => onTakeOrder(order)}
-                          icon={<Zap size={14} />}
-                        >
-                          Take
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                ))
-              ) : (
-                <tr>
-                  <td colSpan={7} className="px-6 py-20 text-center">
-                    <div className="flex flex-col items-center gap-3">
-                      <div className="h-12 w-12 rounded-full bg-surface-overlay flex items-center justify-center border border-border">
-                        <Filter className="text-text-muted" />
-                      </div>
-                      <p className="text-text-secondary font-medium">
-                        No active orders matching filters.
-                      </p>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={resetFilters}
-                      >
-                        Clear Filters
-                      </Button>
-                    </div>
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <OrderListTable
+        orders={filteredOrders}
+        sortKey={sortConfig.key}
+        sortDirection={sortConfig.direction}
+        onSort={handleSort}
+        onTakeOrder={onTakeOrder}
+        onViewDetails={setDetailsOrder}
+        onClearFilters={hasActiveFilters ? resetFilters : undefined}
+        emptyTitle="No active orders matching filters."
+        emptyDescription="Adjust filters or clear them to browse all open orders."
+        pageSize={8}
+      />
 
       <OrderDetailsModal
         order={detailsOrder}

--- a/frontend/src/components/marketplace/OrderListTable.tsx
+++ b/frontend/src/components/marketplace/OrderListTable.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { ReactNode, useMemo } from "react";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { Button, PaginationControls, StatusBadge } from "@/components/ui";
+import { usePagination } from "@/hooks/usePagination";
+import { Order, OrderStatus } from "@/types";
+import { cn } from "@/lib/utils";
+
+export type OrderSortKey = "price" | "amount" | "timestamp";
+export type OrderSortDirection = "asc" | "desc";
+
+export interface OrderListColumn {
+  key: string;
+  label: string;
+  className?: string;
+  sortable?: boolean;
+  sortKey?: OrderSortKey;
+  render: (order: Order) => ReactNode;
+}
+
+interface OrderListTableProps {
+  orders: Order[];
+  columns?: OrderListColumn[];
+  loading?: boolean;
+  emptyTitle?: string;
+  emptyDescription?: string;
+  pageSize?: number;
+  sortKey: OrderSortKey;
+  sortDirection: OrderSortDirection;
+  onSort: (key: OrderSortKey) => void;
+  onTakeOrder: (order: Order) => void;
+  onViewDetails: (order: Order) => void;
+  onClearFilters?: () => void;
+  takeButtonDisabled?: (order: Order) => boolean;
+}
+
+function parseNumeric(value: string) {
+  return Number(value.replace(/,/g, "")) || 0;
+}
+
+function compareOrders(a: Order, b: Order, sortKey: OrderSortKey, sortDirection: OrderSortDirection) {
+  const multiplier = sortDirection === "asc" ? 1 : -1;
+
+  if (sortKey === "timestamp") {
+    return (new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()) * multiplier;
+  }
+
+  if (sortKey === "price") {
+    return (parseNumeric(a.price) - parseNumeric(b.price)) * multiplier;
+  }
+
+  return (parseNumeric(a.amount) - parseNumeric(b.amount)) * multiplier;
+}
+
+function SortIndicator({
+  isActive,
+  direction,
+}: {
+  isActive: boolean;
+  direction: OrderSortDirection;
+}) {
+  if (!isActive) {
+    return <ArrowUpDown size={12} className="text-text-muted" aria-hidden="true" />;
+  }
+
+  if (direction === "asc") {
+    return <ArrowUp size={12} className="text-brand-500" aria-hidden="true" />;
+  }
+
+  return <ArrowDown size={12} className="text-brand-500" aria-hidden="true" />;
+}
+
+function defaultColumns(onViewDetails: (order: Order) => void, onTakeOrder: (order: Order) => void, takeButtonDisabled?: (order: Order) => boolean): OrderListColumn[] {
+  return [
+    {
+      key: "pair",
+      label: "Pair",
+      className: "px-6 py-4",
+      render: (order) => (
+        <div className="flex flex-col">
+          <span className="font-bold text-text-primary">{order.pair}</span>
+          <span className="text-[10px] text-text-muted uppercase tracking-tighter">
+            {order.chainIn} ↔ {order.chainOut}
+          </span>
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      label: "Status",
+      className: "px-6 py-4",
+      render: (order) => (
+        <StatusBadge
+          size="sm"
+          showIcon={false}
+          variant={order.status === OrderStatus.OPEN ? "success" : order.status === OrderStatus.FILLED ? "info" : "cancelled"}
+          label={order.status.toUpperCase()}
+        />
+      ),
+    },
+    {
+      key: "amount",
+      label: "Amount",
+      sortable: true,
+      sortKey: "amount",
+      className: "px-6 py-4 font-mono text-sm text-text-primary",
+      render: (order) => `${order.amount} ${order.tokenIn}`,
+    },
+    {
+      key: "price",
+      label: "Price",
+      sortable: true,
+      sortKey: "price",
+      className: "px-6 py-4 font-mono text-sm text-text-secondary",
+      render: (order) => order.price,
+    },
+    {
+      key: "timestamp",
+      label: "Created",
+      sortable: true,
+      sortKey: "timestamp",
+      className: "px-6 py-4 text-xs text-text-secondary",
+      render: (order) =>
+        new Date(order.timestamp).toLocaleString([], {
+          dateStyle: "short",
+          timeStyle: "short",
+        }),
+    },
+    {
+      key: "total",
+      label: "Total",
+      className: "px-6 py-4 font-mono text-sm font-bold text-text-primary",
+      render: (order) => `${order.total} ${order.tokenOut}`,
+    },
+    {
+      key: "actions",
+      label: "",
+      className: "px-4 py-4 text-right",
+      render: (order) => (
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" size="sm" onClick={() => onViewDetails(order)}>
+            Details
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            className="shadow-glow-sm hover:shadow-glow-md"
+            onClick={() => onTakeOrder(order)}
+            disabled={takeButtonDisabled?.(order)}
+          >
+            Take
+          </Button>
+        </div>
+      ),
+    },
+  ];
+}
+
+export function OrderListTable({
+  orders,
+  columns,
+  loading = false,
+  emptyTitle = "No active orders matching filters.",
+  emptyDescription = "Try adjusting or clearing filters to see more results.",
+  pageSize = 8,
+  sortKey,
+  sortDirection,
+  onSort,
+  onTakeOrder,
+  onViewDetails,
+  onClearFilters,
+  takeButtonDisabled,
+}: OrderListTableProps) {
+  const resolvedColumns = useMemo(
+    () => columns ?? defaultColumns(onViewDetails, onTakeOrder, takeButtonDisabled),
+    [columns, onViewDetails, onTakeOrder, takeButtonDisabled]
+  );
+
+  const sortedOrders = useMemo(
+    () => [...orders].sort((a, b) => compareOrders(a, b, sortKey, sortDirection)),
+    [orders, sortDirection, sortKey]
+  );
+
+  const pagination = usePagination(sortedOrders.length, pageSize);
+  const visibleOrders = sortedOrders.slice(pagination.offset, pagination.limit);
+  const loadingRows = useMemo(() => Array.from({ length: Math.min(pageSize, 5) }), [pageSize]);
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-border bg-background/50 overflow-hidden backdrop-blur-sm shadow-xl">
+        <div className="overflow-x-auto">
+          <table className="w-full text-left border-collapse">
+            <thead>
+              <tr className="bg-surface-overlay/50 border-b border-border">
+                {resolvedColumns.map((column) => {
+                  const isActiveSort = column.sortKey === sortKey;
+                  const isSortable = Boolean(column.sortable && column.sortKey);
+
+                  return (
+                    <th
+                      key={column.key}
+                      onClick={() => (isSortable ? onSort(column.sortKey!) : undefined)}
+                      className={cn(
+                        "text-xs font-bold uppercase tracking-wider text-text-muted",
+                        column.className,
+                        isSortable && "cursor-pointer hover:text-text-primary transition-colors"
+                      )}
+                    >
+                      <div className="flex items-center gap-2">
+                        {column.label}
+                        {isSortable && (
+                          <SortIndicator isActive={isActiveSort} direction={sortDirection} />
+                        )}
+                      </div>
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/50">
+              {loading ? (
+                loadingRows.map((_, index) => (
+                  <tr key={`loading-${index}`}>
+                    {resolvedColumns.map((column) => (
+                      <td key={`${column.key}-${index}`} className={cn(column.className, "py-5")}>
+                        <div className="h-4 w-full animate-pulse rounded bg-surface-overlay/80" />
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              ) : visibleOrders.length > 0 ? (
+                visibleOrders.map((order) => (
+                  <tr key={order.id} className="group hover:bg-surface-overlay/30 transition-colors">
+                    {resolvedColumns.map((column) => (
+                      <td key={`${order.id}-${column.key}`} className={column.className}>
+                        {column.render(order)}
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={resolvedColumns.length} className="px-6 py-16 text-center">
+                    <div className="space-y-2">
+                      <p className="font-medium text-text-secondary">{emptyTitle}</p>
+                      <p className="text-sm text-text-muted">{emptyDescription}</p>
+                      {onClearFilters && (
+                        <Button variant="ghost" size="sm" onClick={onClearFilters} className="mt-3">
+                          Clear Filters
+                        </Button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {!loading && sortedOrders.length > 0 && (
+        <PaginationControls
+          page={pagination.page}
+          totalPages={pagination.totalPages}
+          hasPrevious={pagination.hasPrevious}
+          hasNext={pagination.hasNext}
+          onPageChange={pagination.setPage}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `OrderListTable` component for marketplace orders with configurable columns
- implement built-in sorting indicators/behavior, pagination controls, and loading/empty states
- refactor `OrderBookList` to consume the reusable table and keep existing filtering/details/take-order flows

## Test plan
- [x] Run lints on changed files (`ReadLints` clean)
- [ ] Verify sorting toggles correctly for amount, price, and created columns
- [ ] Verify pagination works across multiple pages
- [ ] Verify loading and empty states render correctly

Closes floxxih/ChainBridge#207
