### PR TITLE
fix(frontend): improve freighter wallet connection UX

### DIFF
--- a/frontend/src/components/swap/WalletConnect.tsx
+++ b/frontend/src/components/swap/WalletConnect.tsx
@@ -8,6 +8,7 @@ import { truncateAddress, formatAmount } from "@/lib/utils";
 import { ChainType } from "@/types/wallet";
 import config from "@/lib/config";
 import { WalletConnectionModal } from "@/components/wallet/WalletConnectionModal";
+import { useUnifiedWallet } from "@/components/wallet/UnifiedWalletProvider";
 
 function formatNetworkLabel(network: string | null | undefined): string {
   if (!network) return "Network unavailable";
@@ -43,6 +44,7 @@ export function WalletConnect() {
     connectByChain,
     disconnectActiveWallet,
     balance,
+    error,
   } = useUnifiedWallet();
   const [isOpen, setIsOpen] = useState(false);
   const toast = useToast();
@@ -55,7 +57,7 @@ export function WalletConnect() {
     try {
       await connectByChain(targetChain);
 
-      if (targetChain === "stellar" && isUnsupportedNetwork) {
+      if (isUnsupportedNetwork) {
         toast.warning(
           targetChain === "stellar" ? "Unsupported Stellar network" : "Unsupported Ethereum network",
           targetChain === "stellar"
@@ -95,7 +97,7 @@ export function WalletConnect() {
             {activeChain === "stellar" && (
               <span className="text-[10px] text-text-muted">Network: {networkLabel}</span>
             )}
-            {chain === "ethereum" && (
+            {activeChain === "ethereum" && (
               <span className="text-[10px] text-text-muted">Network: {networkLabel}</span>
             )}
           </div>
@@ -125,7 +127,7 @@ export function WalletConnect() {
             </p>
           </div>
         )}
-        {chain === "ethereum" && isUnsupportedNetwork && (
+        {activeChain === "ethereum" && isUnsupportedNetwork && (
           <div className="flex max-w-xs items-start gap-2 rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-left text-xs text-amber-200">
             <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
             <p>
@@ -155,6 +157,11 @@ export function WalletConnect() {
         isConnecting={isConnecting}
         onConnect={handleConnect}
       />
+      {error && (
+        <p className="mt-2 max-w-xs text-xs text-red-400" role="alert">
+          {error}
+        </p>
+      )}
     </>
   );
 }

--- a/frontend/src/lib/wallets/stellar.ts
+++ b/frontend/src/lib/wallets/stellar.ts
@@ -5,6 +5,8 @@ import config from "@/lib/config";
 
 type FreighterApi = {
   isConnected?: () => Promise<boolean | { isConnected?: boolean; error?: string }>;
+  isAllowed?: () => Promise<boolean>;
+  setAllowed?: () => Promise<boolean>;
   getPublicKey?: () => Promise<string>;
   getNetwork?: () => Promise<string | { network?: string; networkPassphrase?: string }>;
   signTransaction?: (xdr: string, options: { network: string }) => Promise<any>;
@@ -31,14 +33,28 @@ export class StellarAdapter implements WalletAdapter {
   }
 
   async connect() {
+    if (!freighterApi.getPublicKey) {
+      throw new Error("Freighter wallet not found");
+    }
+
     const connectionState = await freighterApi.isConnected?.();
-    const connected =
+    const extensionConnected =
       typeof connectionState === "boolean"
         ? connectionState
         : Boolean(connectionState?.isConnected);
 
-    if (!connected || !freighterApi.getPublicKey) {
-      throw new Error("Freighter wallet not found or disconnected");
+    if (!extensionConnected) {
+      throw new Error("Freighter extension is not available");
+    }
+
+    if (freighterApi.isAllowed && freighterApi.setAllowed) {
+      const isAllowed = await freighterApi.isAllowed();
+      if (!isAllowed) {
+        const approved = await freighterApi.setAllowed();
+        if (!approved) {
+          throw new Error("Freighter connection request was declined");
+        }
+      }
     }
 
     const publicKey = await freighterApi.getPublicKey();


### PR DESCRIPTION
## Summary
- implement a safer Freighter connection flow by validating extension availability and requesting permission before reading the public key
- fix wallet header state rendering by wiring `useUnifiedWallet` correctly and using the active chain for network display
- surface wallet connection failures in the UI so Freighter errors are visible to users

## Test plan
- [ ] Connect Freighter from the header and approve permission; verify connected account and network are shown
- [ ] Disconnect wallet and verify the header returns to the disconnected state
- [ ] Reject Freighter permission (or disable extension) and verify error toast + inline error message are shown

Closes floxxih/ChainBridge#191
