### PR TITLE
adds four interconnected swap flow features to the frontend

### DIFF
--- a/frontend/src/app/(swap)/swap/page.tsx
+++ b/frontend/src/app/(swap)/swap/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import dynamic from "next/dynamic";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertCircle, ArrowRightLeft, Info, Settings, Share2, Vote, Waves } from "lucide-react";
 
 import { Badge, Button, Card, CardContent, CardFooter, CardHeader, Input } from "@/components/ui";
@@ -25,6 +25,24 @@ const FeeWarningBanner = dynamic(() =>
 import { fetchQuotePreview, type QuotePreview } from "@/lib/quoteApi";
 import { useI18n } from "@/components/i18n/I18nProvider";
 import { useUnifiedWallet } from "@/components/wallet/UnifiedWalletProvider";
+import {
+  RiskDisclosureModal,
+  RISK_ACCEPTANCE_KEY,
+} from "@/components/swap/RiskDisclosureModal";
+import {
+  SlippageExpirationControls,
+  SLIPPAGE_DEFAULT,
+  SLIPPAGE_MIN,
+  SLIPPAGE_MAX,
+  EXPIRATION_DEFAULT_MINUTES,
+} from "@/components/swap/SlippageExpirationControls";
+import { SwapReviewModal } from "@/components/swap/SwapReviewModal";
+import { SwapSigningModal } from "@/components/swap/SwapSigningModal";
+import {
+  TransactionLifecycle,
+  TransactionStepKey,
+  TransactionStepStatus,
+} from "@/types";
 
 type ChainId = "stellar" | "bitcoin" | "ethereum";
 
@@ -33,6 +51,57 @@ const CHAINS: Array<{ id: ChainId; label: string; tokens: string[] }> = [
   { id: "bitcoin", label: "Bitcoin", tokens: ["BTC"] },
   { id: "ethereum", label: "Ethereum", tokens: ["ETH", "USDC"] },
 ];
+
+function buildSigningLifecycle(
+  current: TransactionStepKey,
+  signStatus: TransactionStepStatus,
+  broadcastStatus: TransactionStepStatus,
+  confirmStatus: TransactionStepStatus,
+  retryable = false
+): TransactionLifecycle {
+  const desc = (base: string, active: string, done: string, status: TransactionStepStatus) =>
+    status === "active" ? active : status === "completed" ? done : base;
+
+  return {
+    currentStep: current,
+    retryable,
+    steps: [
+      {
+        key: "sign",
+        label: "Sign Transaction",
+        status: signStatus,
+        description: desc(
+          "Sign the transaction in your wallet",
+          "Waiting for wallet signature…",
+          "Transaction signed",
+          signStatus
+        ),
+      },
+      {
+        key: "broadcast",
+        label: "Broadcast",
+        status: broadcastStatus,
+        description: desc(
+          "Submit transaction to network",
+          "Submitting to network…",
+          "Transaction broadcast",
+          broadcastStatus
+        ),
+      },
+      {
+        key: "confirm",
+        label: "Confirm",
+        status: confirmStatus,
+        description: desc(
+          "Awaiting on-chain confirmation",
+          "Awaiting on-chain confirmation…",
+          "Confirmed on-chain",
+          confirmStatus
+        ),
+      },
+    ],
+  };
+}
 
 export default function SwapPage() {
   const { isConnected } = useUnifiedWallet();
@@ -49,6 +118,18 @@ export default function SwapPage() {
   const [quoteLoading, setQuoteLoading] = useState(false);
   const [quoteUpdatedAt, setQuoteUpdatedAt] = useState<number | null>(null);
   const [clockMs, setClockMs] = useState(Date.now());
+
+  // Slippage & expiration controls (issue #201)
+  const [slippage, setSlippage] = useState(SLIPPAGE_DEFAULT);
+  const [expirationMinutes, setExpirationMinutes] = useState(EXPIRATION_DEFAULT_MINUTES);
+
+  // Modal state (issues #165, #203, #204)
+  const [riskModalOpen, setRiskModalOpen] = useState(false);
+  const [reviewModalOpen, setReviewModalOpen] = useState(false);
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [signingModalOpen, setSigningModalOpen] = useState(false);
+  const [signingLifecycle, setSigningLifecycle] = useState<TransactionLifecycle | null>(null);
+  const signingGenRef = useRef(0);
 
   useEffect(() => {
     const timer = window.setInterval(() => setClockMs(Date.now()), 1000);
@@ -125,6 +206,100 @@ export default function SwapPage() {
       maximumFractionDigits: 8,
     })
     : "";
+
+  const slippageInvalid =
+    Number.isNaN(slippage) || slippage < SLIPPAGE_MIN || slippage > SLIPPAGE_MAX;
+
+  // --- Modal flow handlers ---
+
+  const openReviewModal = () => setReviewModalOpen(true);
+
+  /** Called when "Initialize Atomic Swap" is clicked. */
+  const handleInitiateSwap = () => {
+    let accepted = false;
+    if (typeof window !== "undefined") {
+      try {
+        const stored = localStorage.getItem(RISK_ACCEPTANCE_KEY);
+        accepted = stored ? JSON.parse(stored)?.accepted === true : false;
+      } catch {
+        accepted = false;
+      }
+    }
+    if (!accepted) {
+      setRiskModalOpen(true);
+    } else {
+      openReviewModal();
+    }
+  };
+
+  /** Called when the user accepts the risk disclosure. */
+  const handleRiskAccepted = () => {
+    setRiskModalOpen(false);
+    openReviewModal();
+  };
+
+  /** Runs the simulated signing flow. Uses a generation counter so stale runs self-abort. */
+  const runSigningSimulation = async (gen: number) => {
+    setSigningLifecycle(buildSigningLifecycle("sign", "active", "idle", "idle"));
+
+    await new Promise<void>((r) => setTimeout(r, 2000));
+    if (signingGenRef.current !== gen) return;
+    setSigningLifecycle(buildSigningLifecycle("broadcast", "completed", "active", "idle"));
+
+    await new Promise<void>((r) => setTimeout(r, 2000));
+    if (signingGenRef.current !== gen) return;
+    setSigningLifecycle(buildSigningLifecycle("confirm", "completed", "completed", "active"));
+
+    await new Promise<void>((r) => setTimeout(r, 2000));
+    if (signingGenRef.current !== gen) return;
+    setSigningLifecycle(buildSigningLifecycle("confirm", "completed", "completed", "completed"));
+  };
+
+  /** Called when the user confirms the swap in the review modal. */
+  const handleSwapConfirm = async () => {
+    setIsConfirming(true);
+    await new Promise<void>((r) => setTimeout(r, 400));
+    setIsConfirming(false);
+    setReviewModalOpen(false);
+    setSigningModalOpen(true);
+    const gen = ++signingGenRef.current;
+    void runSigningSimulation(gen);
+  };
+
+  /** Retry: cancel any running simulation and restart. */
+  const handleSigningRetry = () => {
+    const gen = ++signingGenRef.current;
+    void runSigningSimulation(gen);
+  };
+
+  /** Cancel signing: abort simulation and close. */
+  const handleSigningCancel = () => {
+    signingGenRef.current++;
+    setSigningModalOpen(false);
+    setSigningLifecycle(null);
+  };
+
+  const handleSigningClose = () => {
+    setSigningModalOpen(false);
+    setSigningLifecycle(null);
+  };
+
+  const reviewSwapDetails = {
+    fromAsset,
+    fromChain: sourceInfo?.label ?? sourceChain,
+    fromAmount: amount || "0",
+    toAsset,
+    toChain: destInfo?.label ?? destChain,
+    toAmount: toAmount || "~",
+    estimatedFees:
+      quote?.feeBreakdown.total_usd_estimate != null
+        ? `~$${quote.feeBreakdown.total_usd_estimate.toFixed(2)} USD`
+        : "See quote preview",
+    timelockHours,
+    route: `${sourceInfo?.label ?? sourceChain} → ${destInfo?.label ?? destChain}`,
+    slippage,
+    expirationMinutes,
+  };
 
   return (
     <div className="container mx-auto max-w-3xl px-4 py-12 md:py-20 animate-fade-in">
@@ -271,6 +446,14 @@ export default function SwapPage() {
             onTimelockChange={setTimelockHours}
           />
 
+          {/* Slippage & expiration controls (issue #201) */}
+          <SlippageExpirationControls
+            slippage={slippage}
+            expirationMinutes={expirationMinutes}
+            onSlippageChange={setSlippage}
+            onExpirationChange={setExpirationMinutes}
+          />
+
           <div className="rounded-xl border border-border bg-background/60 p-4">
             <div className="mb-3 flex items-center justify-between">
               <span className="text-sm font-medium text-text-primary">Advanced Execution</span>
@@ -307,7 +490,8 @@ export default function SwapPage() {
         <CardFooter className="bg-surface-overlay/30">
           <Button
             className="w-full h-12 rounded-xl text-lg font-bold"
-            disabled={!isConnected || !amount || !!quoteError}
+            disabled={!isConnected || !amount || !!quoteError || slippageInvalid}
+            onClick={handleInitiateSwap}
           >
             {isConnected ? "Initialize Atomic Swap" : "Connect Wallet to Swap"}
           </Button>
@@ -358,12 +542,37 @@ export default function SwapPage() {
           <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-2xl bg-brand-500/10 text-brand-500">
             <Share2 className="h-5 w-5" />
           </div>
-          <h3 className="font-semibold text-text-primary">Share & Earn</h3>
+          <h3 className="font-semibold text-text-primary">Share &amp; Earn</h3>
           <p className="mt-2 text-sm text-text-secondary">
             Generate referral links, QR codes, and performance analytics.
           </p>
         </Link>
       </div>
+
+      {/* Risk disclosure modal — shown before first swap (issue #165) */}
+      <RiskDisclosureModal
+        open={riskModalOpen}
+        onAccept={handleRiskAccepted}
+        onClose={() => setRiskModalOpen(false)}
+      />
+
+      {/* Swap review modal — confirmation before signing (issue #203) */}
+      <SwapReviewModal
+        open={reviewModalOpen}
+        onClose={() => setReviewModalOpen(false)}
+        onConfirm={() => void handleSwapConfirm()}
+        isConfirming={isConfirming}
+        swapDetails={reviewSwapDetails}
+      />
+
+      {/* Transaction signing modal — progress, timeout, retry (issue #204) */}
+      <SwapSigningModal
+        open={signingModalOpen}
+        onClose={handleSigningClose}
+        onCancel={handleSigningCancel}
+        onRetry={handleSigningRetry}
+        lifecycle={signingLifecycle}
+      />
     </div>
   );
 }

--- a/frontend/src/components/swap/RiskDisclosureModal.tsx
+++ b/frontend/src/components/swap/RiskDisclosureModal.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import { ShieldAlert } from "lucide-react";
+import { Modal } from "@/components/ui/modal";
+import { Button } from "@/components/ui";
+
+export const RISK_DISCLOSURE_VERSION = "1";
+export const RISK_ACCEPTANCE_KEY = `chainbridge_risk_accepted_v${RISK_DISCLOSURE_VERSION}`;
+
+const RISK_ITEMS = [
+  {
+    title: "Price Volatility",
+    body: "Asset prices can shift significantly between initiation and settlement. You may receive less value than the quoted estimate.",
+  },
+  {
+    title: "HTLC Timelock Expiry",
+    body: "If the counterparty does not complete the swap before the timelock expires, the swap fails and your funds are automatically refunded.",
+  },
+  {
+    title: "Smart Contract Risk",
+    body: "HTLC contracts are audited, but all software carries inherent risk. Only swap amounts you can afford to lose.",
+  },
+  {
+    title: "Counterparty Risk",
+    body: "Live swaps require an active counterparty. An unresponsive counterparty causes expiry and a full refund, not loss of funds.",
+  },
+  {
+    title: "No Custodial Protection",
+    body: "ChainBridge is non-custodial. You are solely responsible for your wallet keys and all transaction actions you take.",
+  },
+];
+
+interface RiskDisclosureModalProps {
+  open: boolean;
+  onAccept: () => void;
+  onClose: () => void;
+}
+
+export function RiskDisclosureModal({ open, onAccept, onClose }: RiskDisclosureModalProps) {
+  const [checked, setChecked] = useState(false);
+
+  const handleAccept = () => {
+    if (!checked) return;
+    if (typeof window !== "undefined") {
+      localStorage.setItem(
+        RISK_ACCEPTANCE_KEY,
+        JSON.stringify({ accepted: true, at: new Date().toISOString() })
+      );
+    }
+    onAccept();
+  };
+
+  const handleClose = () => {
+    setChecked(false);
+    onClose();
+  };
+
+  return (
+    <Modal open={open} onClose={handleClose} size="md">
+      <div className="flex flex-col gap-5">
+        <div className="text-center space-y-1">
+          <h3 className="text-lg font-semibold text-text-primary">Swap Risk Disclosure</h3>
+          <p className="text-sm text-text-secondary">
+            Version {RISK_DISCLOSURE_VERSION} — Required before your first swap
+          </p>
+        </div>
+
+        <div className="flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/5 p-4">
+          <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+          <p className="text-sm text-amber-600 dark:text-amber-400">
+            Cross-chain atomic swaps involve financial and technical risks. Please read carefully
+            before proceeding.
+          </p>
+        </div>
+
+        <ul className="max-h-64 space-y-3 overflow-y-auto pr-1">
+          {RISK_ITEMS.map((item) => (
+            <li key={item.title} className="rounded-xl border border-border bg-surface-raised p-4">
+              <p className="text-sm font-semibold text-text-primary">{item.title}</p>
+              <p className="mt-1 text-sm text-text-secondary">{item.body}</p>
+            </li>
+          ))}
+        </ul>
+
+        <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-border bg-surface-overlay/30 p-4">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-4 w-4 cursor-pointer rounded accent-brand-500"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
+          />
+          <span className="text-sm text-text-primary">
+            I have read and understood these risks and accept full responsibility for my swap
+            actions.
+          </span>
+        </label>
+
+        <div className="flex gap-3">
+          <Button variant="secondary" className="flex-1" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" className="flex-1" onClick={handleAccept} disabled={!checked}>
+            Accept &amp; Continue
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/swap/SlippageExpirationControls.tsx
+++ b/frontend/src/components/swap/SlippageExpirationControls.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+
+// Slippage: default 0.5%, valid range 0.1%–50%
+export const SLIPPAGE_DEFAULT = 0.5;
+export const SLIPPAGE_MIN = 0.1;
+export const SLIPPAGE_MAX = 50;
+
+// Order expiration: default 30 minutes
+export const EXPIRATION_DEFAULT_MINUTES = 30;
+
+const SLIPPAGE_PRESETS = [0.1, 0.5, 1.0];
+
+const EXPIRATION_OPTIONS: Array<{ label: string; value: number }> = [
+  { label: "5 min", value: 5 },
+  { label: "15 min", value: 15 },
+  { label: "30 min", value: 30 },
+  { label: "1 hr", value: 60 },
+  { label: "24 hr", value: 1440 },
+];
+
+interface SlippageExpirationControlsProps {
+  slippage: number;
+  expirationMinutes: number;
+  onSlippageChange: (value: number) => void;
+  onExpirationChange: (value: number) => void;
+}
+
+export function SlippageExpirationControls({
+  slippage,
+  expirationMinutes,
+  onSlippageChange,
+  onExpirationChange,
+}: SlippageExpirationControlsProps) {
+  const slippageInvalid =
+    Number.isNaN(slippage) || slippage < SLIPPAGE_MIN || slippage > SLIPPAGE_MAX;
+  const slippageHigh = !slippageInvalid && slippage > 5;
+
+  return (
+    <div className="rounded-xl border border-border bg-background/60 p-4 space-y-5">
+      <p className="text-sm font-medium text-text-primary">Slippage &amp; Expiration</p>
+
+      {/* Slippage tolerance */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <label className="text-xs font-medium text-text-secondary">Slippage Tolerance</label>
+          <span className="text-xs text-text-muted">Default: {SLIPPAGE_DEFAULT}%</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-1">
+            <input
+              type="number"
+              min={SLIPPAGE_MIN}
+              max={SLIPPAGE_MAX}
+              step="0.1"
+              value={Number.isNaN(slippage) ? "" : slippage}
+              onChange={(e) => {
+                const v = parseFloat(e.target.value);
+                onSlippageChange(Number.isNaN(v) ? SLIPPAGE_DEFAULT : v);
+              }}
+              className="w-20 rounded-lg border border-border bg-surface-raised px-3 py-1.5 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-brand-500/50"
+            />
+            <span className="text-sm text-text-muted">%</span>
+          </div>
+          <div className="flex gap-1">
+            {SLIPPAGE_PRESETS.map((preset) => (
+              <button
+                key={preset}
+                type="button"
+                onClick={() => onSlippageChange(preset)}
+                className={`rounded-lg border px-2.5 py-1.5 text-xs transition ${
+                  slippage === preset
+                    ? "border-brand-500 bg-brand-500/10 text-brand-500"
+                    : "border-border bg-surface-overlay/30 text-text-secondary hover:border-brand-500/30"
+                }`}
+              >
+                {preset}%
+              </button>
+            ))}
+          </div>
+        </div>
+        {slippageInvalid && (
+          <p className="flex items-center gap-1.5 text-xs text-status-error">
+            <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+            Must be between {SLIPPAGE_MIN}% and {SLIPPAGE_MAX}%
+          </p>
+        )}
+        {slippageHigh && (
+          <p className="flex items-center gap-1.5 text-xs text-amber-400">
+            <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+            High slippage — execution price may differ significantly
+          </p>
+        )}
+      </div>
+
+      {/* Order expiration */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <label className="text-xs font-medium text-text-secondary">Order Expiration</label>
+          <span className="text-xs text-text-muted">Default: 30 min</span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {EXPIRATION_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => onExpirationChange(opt.value)}
+              className={`rounded-lg border px-3 py-1.5 text-xs transition ${
+                expirationMinutes === opt.value
+                  ? "border-brand-500 bg-brand-500/10 text-brand-500"
+                  : "border-border bg-surface-overlay/30 text-text-secondary hover:border-brand-500/30"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/swap/SwapReviewModal.tsx
+++ b/frontend/src/components/swap/SwapReviewModal.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Modal } from "@/components/ui/modal";
+import { SwapReviewSummary } from "./SwapReviewSummary";
+
+interface SwapReviewModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isConfirming: boolean;
+  swapDetails: {
+    fromAsset: string;
+    fromChain: string;
+    fromAmount: string;
+    toAsset: string;
+    toChain: string;
+    toAmount: string;
+    estimatedFees: string;
+    timelockHours: number;
+    route: string;
+    slippage: number;
+    expirationMinutes: number;
+  };
+}
+
+export function SwapReviewModal({
+  open,
+  onClose,
+  onConfirm,
+  isConfirming,
+  swapDetails,
+}: SwapReviewModalProps) {
+  return (
+    <Modal
+      open={open}
+      onClose={isConfirming ? () => {} : onClose}
+      size="md"
+    >
+      <div className="flex flex-col gap-4">
+        <SwapReviewSummary
+          onConfirm={onConfirm}
+          onCancel={onClose}
+          isConfirming={isConfirming}
+          swapDetails={swapDetails}
+        />
+
+        {/* Slippage and expiration are part of the payload preview */}
+        <div className="rounded-xl border border-border bg-surface-overlay/30 p-3 space-y-2 text-sm">
+          <div className="flex justify-between">
+            <span className="text-text-secondary">Slippage Tolerance</span>
+            <span className="font-medium text-text-primary">{swapDetails.slippage}%</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-text-secondary">Order Expiration</span>
+            <span className="font-medium text-text-primary">
+              {swapDetails.expirationMinutes >= 60
+                ? `${swapDetails.expirationMinutes / 60} hr`
+                : `${swapDetails.expirationMinutes} min`}
+            </span>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/swap/SwapSigningModal.tsx
+++ b/frontend/src/components/swap/SwapSigningModal.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { AlertCircle, Clock } from "lucide-react";
+import { Modal } from "@/components/ui/modal";
+import { Button } from "@/components/ui";
+import { SigningProgressStepper } from "@/components/transactions/SigningProgressStepper";
+import { TransactionLifecycle } from "@/types";
+
+const SIGNING_TIMEOUT_SECONDS = 120;
+
+interface SwapSigningModalProps {
+  open: boolean;
+  onClose: () => void;
+  onCancel: () => void;
+  onRetry: () => void;
+  lifecycle: TransactionLifecycle | null;
+}
+
+export function SwapSigningModal({
+  open,
+  onClose,
+  onCancel,
+  onRetry,
+  lifecycle,
+}: SwapSigningModalProps) {
+  const [elapsed, setElapsed] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setElapsed(0);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      return;
+    }
+    setElapsed(0);
+    intervalRef.current = setInterval(() => setElapsed((s) => s + 1), 1000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [open]);
+
+  const isCompleted = lifecycle?.steps.every((s) => s.status === "completed") ?? false;
+  const hasError = lifecycle?.steps.some((s) => s.status === "error") ?? false;
+  const isActiveStep = lifecycle?.steps.some((s) => s.status === "active") ?? false;
+  // After sign step completes, wallet interaction is done
+  const isSigned =
+    lifecycle?.steps.find((s) => s.key === "sign")?.status === "completed" ?? false;
+  const isTimedOut = !isCompleted && !hasError && elapsed >= SIGNING_TIMEOUT_SECONDS;
+  const remaining = Math.max(0, SIGNING_TIMEOUT_SECONDS - elapsed);
+
+  // Allow closing only once completed, errored, or timed out
+  const canClose = isCompleted || hasError || isTimedOut;
+
+  return (
+    <Modal
+      open={open}
+      onClose={canClose ? onClose : () => {}}
+      size="md"
+    >
+      <div className="flex flex-col gap-5">
+        <div className="text-center space-y-1">
+          <h3 className="text-lg font-semibold text-text-primary">Transaction Signing</h3>
+          <p className="text-sm text-text-secondary">
+            {isCompleted
+              ? "Swap submitted successfully."
+              : hasError
+              ? "An error occurred during signing."
+              : "Please review and sign the transaction in your wallet."}
+          </p>
+        </div>
+
+        {lifecycle && (
+          <SigningProgressStepper
+            lifecycle={lifecycle}
+            onRetry={lifecycle.retryable ? onRetry : undefined}
+            retryLabel="Retry Swap"
+          />
+        )}
+
+        {/* Countdown shown while waiting for wallet signature */}
+        {isActiveStep && !isSigned && !isTimedOut && !hasError && (
+          <div className="flex items-center gap-2 rounded-xl border border-brand-500/20 bg-brand-500/5 p-3 text-sm text-text-secondary">
+            <Clock className="h-4 w-4 shrink-0 text-brand-500" />
+            <span>Waiting for wallet — {remaining}s remaining</span>
+          </div>
+        )}
+
+        {isTimedOut && (
+          <div className="flex items-start gap-3 rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+            <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+            <div>
+              <p className="text-sm font-semibold text-text-primary">Signing timed out</p>
+              <p className="mt-1 text-sm text-text-secondary">
+                Your wallet did not respond in time. You can retry or cancel the swap.
+              </p>
+            </div>
+          </div>
+        )}
+
+        <div className="flex gap-3 border-t border-border pt-4">
+          {isCompleted ? (
+            <Button variant="primary" className="flex-1" onClick={onClose}>
+              Done
+            </Button>
+          ) : (
+            <>
+              <Button
+                variant="secondary"
+                className="flex-1"
+                onClick={onCancel}
+                disabled={isSigned && !hasError && !isTimedOut}
+              >
+                Cancel
+              </Button>
+              {(isTimedOut || hasError) && (
+                <Button variant="primary" className="flex-1" onClick={onRetry}>
+                  Retry
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
Summary

Resolves #165, closes #201, closes #203, closes #204

This PR adds four interconnected swap flow features to the frontend:

---

### What was done

**Issue #165 — Swap risk disclosure & acknowledgement modal**

* New `RiskDisclosureModal` component (`src/components/swap/RiskDisclosureModal.tsx`)
* Shows 5 risk disclosures (price volatility, HTLC expiry, smart contract risk, counterparty
  risk, no custodial protection)
* User must check an explicit acknowledgement checkbox before proceeding
* Acceptance is written to `localStorage` under a versioned key
  (`chainbridge_risk_accepted_v1`) so it only shows once per device per disclosure version
* Bumping `RISK_DISCLOSURE_VERSION` forces re-acceptance on the next swap attempt

**Issue #201 — Slippage and expiration controls**

* New `SlippageExpirationControls` component
  (`src/components/swap/SlippageExpirationControls.tsx`)
* Slippage: default 0.5%, preset quick-picks (0.1 / 0.5 / 1.0%), free numeric input, validated
  range 0.1%–50%; inline warning above 5%
* Expiration: default 30 min, segmented picker (5 min / 15 min / 30 min / 1 hr / 24 hr)
* Both values are surfaced in the swap review modal as part of the payload preview before any
  transaction is signed

**Issue #203 — Swap review modal**

* New `SwapReviewModal` component (`src/components/swap/SwapReviewModal.tsx`) wrapping the
  existing `SwapReviewSummary` inside the accessible Modal primitive
* Displays all critical fields: from/to assets, chains, amounts, estimated fees, HTLC
  timelock, route, slippage tolerance, and order expiration
* Confirm button is the only path forward; Cancel button and backdrop click both close safely
* Modal blocks closure while `isConfirming` to prevent accidental dismissal mid-submission

**Issue #204 — Transaction signing state UI**

* New `SwapSigningModal` component (`src/components/swap/SwapSigningModal.tsx`)
* Reuses `SigningProgressStepper` for step-by-step progress (Sign → Broadcast → Confirm)
* Countdown timer shows remaining seconds (120 s window); displays a labelled timeout warning
  when expired
* Cancel is available while the sign step is pending; disabled once wallet signature is
  obtained
* Retry button appears on timeout or error and restarts the signing flow

---

### Wiring (`src/app/(swap)/swap/page.tsx`)

* `slippage` and `expirationMinutes` state added with documented defaults
* `handleInitiateSwap` checks `localStorage` for prior risk acceptance; routes to risk modal
  (first time) or review modal (already accepted)
* Full modal sequence: **risk disclosure → swap review → signing progress**
* `buildSigningLifecycle` helper builds typed `TransactionLifecycle` objects;
  `runSigningSimulation` simulates step progression with a generation counter to abort stale
  runs on retry/cancel
* "Initialize Atomic Swap" button disabled when slippage is out of valid range

---

### Files changed

* `src/components/swap/RiskDisclosureModal.tsx` (new)
* `src/components/swap/SlippageExpirationControls.tsx` (new)
* `src/components/swap/SwapReviewModal.tsx` (new)
* `src/components/swap/SwapSigningModal.tsx` (new)
* `src/app/(swap)/swap/page.tsx` (updated)
