### PR TITLE
[Frontend] Add error boundary at app layout level

### DIFF
--- a/frontend/src/__tests__/errorBoundary.test.tsx
+++ b/frontend/src/__tests__/errorBoundary.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import * as errorMonitor from "@/lib/errorMonitor";
+
+function Boom(): JSX.Element {
+  throw new Error("boom");
+}
+
+describe("ErrorBoundary", () => {
+  it("renders fallback UI, logs with component context, and recovers when reset keys change", async () => {
+    const user = userEvent.setup();
+    const captureErrorSpy = jest.spyOn(errorMonitor, "captureError").mockImplementation(() => {});
+
+    const { rerender } = render(
+      <ErrorBoundary contextName="AppLayout" resetKeys={["/swap"]}>
+        <Boom />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(captureErrorSpy).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        errorBoundary: "AppLayout",
+        componentStack: expect.any(String),
+      })
+    );
+
+    rerender(
+      <ErrorBoundary contextName="AppLayout" resetKeys={["/dashboard"]}>
+        <div>Recovered after navigation</div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Recovered after navigation")).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary contextName="AppLayout" resetKeys={["/swap"]}>
+        <Boom />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Try again")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+    captureErrorSpy.mockRestore();
+  });
+});

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { Footer } from "@/components/layout/Footer";
 import { ServiceWorkerRegistrar } from "@/components/ServiceWorkerRegistrar";
 import { EnvValidationWrapper } from "@/components/EnvValidationWrapper";
 import { cn } from "@/lib/utils";
+import { AppLayoutErrorBoundary } from "@/components/layout/AppLayoutErrorBoundary";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -93,26 +94,28 @@ export default function RootLayout({
         >
           Skip to main content
         </a>
-        <EnvValidationWrapper>
-          <Providers>
-            <ServiceWorkerRegistrar />
-            <div className="flex min-h-screen">
-              {/* Desktop Sidebar */}
-              <Sidebar />
+        <AppLayoutErrorBoundary>
+          <EnvValidationWrapper>
+            <Providers>
+              <ServiceWorkerRegistrar />
+              <div className="flex min-h-screen">
+                {/* Desktop Sidebar */}
+                <Sidebar />
 
-              {/* Main Shell */}
-              <div className="relative flex flex-1 flex-col lg:pl-64">
-                <Navbar />
-                <main id="main-content" className="flex-1" tabIndex={-1}>
-                  <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-                    {children}
-                  </div>
-                </main>
-                <Footer />
+                {/* Main Shell */}
+                <div className="relative flex flex-1 flex-col lg:pl-64">
+                  <Navbar />
+                  <main id="main-content" className="flex-1" tabIndex={-1}>
+                    <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+                      {children}
+                    </div>
+                  </main>
+                  <Footer />
+                </div>
               </div>
-            </div>
-          </Providers>
-        </EnvValidationWrapper>
+            </Providers>
+          </EnvValidationWrapper>
+        </AppLayoutErrorBoundary>
       </body>
     </html>
   );

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React from "react";
-import { AlertTriangle, RefreshCw } from "lucide-react";
+import { AlertTriangle, RefreshCw, Home } from "lucide-react";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { captureError } from "@/lib/errorMonitor";
 
@@ -9,6 +10,8 @@ interface Props {
   children: React.ReactNode;
   fallback?: React.ReactNode;
   className?: string;
+  resetKeys?: unknown[];
+  contextName?: string;
 }
 
 interface State {
@@ -27,8 +30,25 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
-    console.error("[ErrorBoundary]", error, info.componentStack);
-    captureError(error, { componentStack: info.componentStack ?? "" });
+    const contextName = this.props.contextName ?? "UnknownBoundary";
+    console.error(`[ErrorBoundary:${contextName}]`, error, info.componentStack);
+    captureError(error, {
+      errorBoundary: contextName,
+      componentStack: info.componentStack ?? "",
+    });
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const { resetKeys } = this.props;
+    if (!this.state.hasError || !resetKeys || !prevProps.resetKeys) return;
+
+    const hasResetKeyChanged =
+      resetKeys.length !== prevProps.resetKeys.length ||
+      resetKeys.some((key, index) => !Object.is(key, prevProps.resetKeys?.[index]));
+
+    if (hasResetKeyChanged) {
+      this.handleReset();
+    }
   }
 
   handleReset = () => {
@@ -42,7 +62,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
       return (
         <div
           className={cn(
-            "flex flex-col items-center justify-center rounded-2xl border border-red-500/20 bg-red-500/5 p-10 text-center",
+            "mx-auto flex w-full max-w-lg flex-col items-center justify-center rounded-2xl border border-red-500/20 bg-red-500/5 p-10 text-center",
             this.props.className
           )}
         >
@@ -53,13 +73,22 @@ export class ErrorBoundary extends React.Component<Props, State> {
           <p className="mb-6 max-w-sm text-sm text-text-secondary">
             {this.state.error?.message ?? "An unexpected error occurred."}
           </p>
-          <button
-            onClick={this.handleReset}
-            className="flex items-center gap-2 rounded-xl bg-red-500/10 px-4 py-2 text-sm font-medium text-red-400 transition hover:bg-red-500/20"
-          >
-            <RefreshCw className="h-4 w-4" />
-            Try again
-          </button>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <button
+              onClick={this.handleReset}
+              className="flex items-center gap-2 rounded-xl bg-red-500/10 px-4 py-2 text-sm font-medium text-red-400 transition hover:bg-red-500/20"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Try again
+            </button>
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 rounded-xl border border-border px-4 py-2 text-sm font-medium text-text-secondary transition hover:bg-surface-hover"
+            >
+              <Home className="h-4 w-4" />
+              Go home
+            </Link>
+          </div>
         </div>
       );
     }

--- a/frontend/src/components/layout/AppLayoutErrorBoundary.tsx
+++ b/frontend/src/components/layout/AppLayoutErrorBoundary.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+
+interface AppLayoutErrorBoundaryProps {
+  children: ReactNode;
+}
+
+export function AppLayoutErrorBoundary({ children }: AppLayoutErrorBoundaryProps) {
+  const pathname = usePathname();
+
+  return (
+    <ErrorBoundary resetKeys={[pathname]} contextName="AppLayout">
+      {children}
+    </ErrorBoundary>
+  );
+}


### PR DESCRIPTION
---
name: Pull Request Template
about: Submit changes to ChainBridge
title: ''[Frontend] Add error boundary at app layout level
labels: ''frontend
assignees: ''johnpii1
---

## Description
Brief description of changes.
Description
Added a small AppLayoutErrorBoundary wrapper that uses usePathname() to pass route resetKeys to the boundary (frontend/src/components/layout/AppLayoutErrorBoundary.tsx).
Wrapped the root layout in AppLayoutErrorBoundary in frontend/src/app/layout.tsx so the entire top-level shell is protected.
Extended ErrorBoundary to accept contextName and resetKeys, include the contextName in logs sent to captureError, and auto-reset when resetKeys change, and improved the fallback UI to include Try again and Go home actions (frontend/src/components/ErrorBoundary.tsx).
Added a unit test that exercises fallback rendering, verifies captureError receives the boundary context, and checks reset-key based recovery (frontend/src/__tests__/errorBoundary.test.tsx).


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Related Issues
Closes #244 (issue number)

## Changes Made
List the changes made:
- 
- 
- 

## Testing
Describe the tests you ran to verify your changes:
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

### Test Results
```
Paste test output here
```
Testing
Ran npx eslint src/app/layout.tsx src/components/ErrorBoundary.tsx src/components/layout/AppLayoutErrorBoundary.tsx src/__tests__/errorBoundary.test.tsx and the lint check passed.
Ran npm run type-check which failed due to pre-existing repository TypeScript errors unrelated to these changes (one test typing issue in this patch was fixed before committing).
Ran npm run test -- errorBoundary.test.tsx which could not run in this environment because jest.config.ts requires ts-node (missing in this environment), so the unit test was added but not executed here.



## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
Add any other notes for reviewers.
