### PR TITLE
feat(frontend): resolve UX issues #401 #402 #406 #410

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,15 +1,34 @@
 "use client";
 
-import { Button, Input, Select, CopyButton } from "@/components/ui";
+import { useState } from "react";
+import { Button, Input, CopyButton } from "@/components/ui";
 import Link from "next/link";
 import { PageHeader } from "@/components/layout/PageHeader";
-import { RefreshCw } from "lucide-react";
+import { RefreshCw, Wallet, Globe, Activity } from "lucide-react";
 import { useBreadcrumbs } from "@/hooks/useBreadcrumbs";
 import { PortfolioChainsSection } from "@/components/dashboard/PortfolioChainsSection";
 import { RecentSwapsPreview } from "@/components/dashboard/RecentSwapsPreview";
+import { useWalletStore } from "@/hooks/useWallet";
+import { useSettingsStore } from "@/hooks/useSettings";
+import { useSwapHistoryStore } from "@/hooks/useSwapHistory";
+import { useToast } from "@/hooks/useToast";
 
 export default function DashboardPage() {
   const breadcrumbs = useBreadcrumbs();
+  const { address, isConnected } = useWalletStore();
+  const networkMode = useSettingsStore((s) => s.settings.network.mode);
+  const swapCount = useSwapHistoryStore((s) => s.swaps.length);
+  const { success } = useToast();
+
+  const [displayName, setDisplayName] = useState("");
+  const [email, setEmail] = useState("");
+  const [saved, setSaved] = useState({ displayName: "", email: "" });
+  const isDirty = displayName !== saved.displayName || email !== saved.email;
+
+  function handleSave() {
+    setSaved({ displayName, email });
+    success("Profile saved");
+  }
 
   return (
     <div className="space-y-8">
@@ -25,27 +44,67 @@ export default function DashboardPage() {
         ]}
       />
 
-      {/* Issue #405 — surfaces the existing PortfolioChainCard component
-          (previously orphaned) so the dashboard leads with portfolio
-          context rather than a profile form. */}
       <PortfolioChainsSection />
-
-      {/* Issue #404 — recent swap-history preview. Reads from the
-          persisted swap-history store and links out to `/tracking`. */}
       <RecentSwapsPreview />
 
+      {/* Issue #401 — wallet summary replaces placeholder profile card */}
+      <div className="rounded-xl border border-border bg-surface-overlay p-6 space-y-4">
+        <h2 className="text-xl font-semibold text-text-primary">Wallet Summary</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="flex items-center gap-3 rounded-lg bg-surface-raised p-4">
+            <Wallet className="h-5 w-5 text-brand-500 shrink-0" />
+            <div className="min-w-0">
+              <p className="text-xs text-text-muted">Address</p>
+              {isConnected && address ? (
+                <div className="flex items-center gap-1">
+                  <span className="truncate text-sm font-medium text-text-primary">
+                    {address.slice(0, 8)}…{address.slice(-6)}
+                  </span>
+                  <CopyButton value={address} />
+                </div>
+              ) : (
+                <span className="text-sm text-text-secondary">Not connected</span>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-3 rounded-lg bg-surface-raised p-4">
+            <Globe className="h-5 w-5 text-brand-500 shrink-0" />
+            <div>
+              <p className="text-xs text-text-muted">Network</p>
+              <span className="text-sm font-medium text-text-primary capitalize">{networkMode}</span>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 rounded-lg bg-surface-raised p-4">
+            <Activity className="h-5 w-5 text-brand-500 shrink-0" />
+            <div>
+              <p className="text-xs text-text-muted">Swaps</p>
+              <span className="text-sm font-medium text-text-primary">{swapCount}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Issue #402 — single save action, disabled until changes are made */}
       <div className="rounded-xl border border-border bg-surface-overlay p-6 space-y-6">
         <h2 className="text-xl font-semibold text-text-primary">Profile</h2>
-
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <Input
-            label="Wallet Address"
-            disabled
-            value="0x123...abc"
-            rightElement={<CopyButton value={"0x123...abc"} />}
+            label="Display Name"
+            placeholder="e.g. Satoshi"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
           />
-          <Input label="Display Name" placeholder="e.g. Satoshi" />
-          <Input label="Email" placeholder="your@email.com" />
+          <Input
+            label="Email"
+            placeholder="your@email.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <div className="flex justify-end">
+          <Button variant="primary" size="sm" disabled={!isDirty} onClick={handleSave}>
+            Save Changes
+          </Button>
         </div>
       </div>
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { ServiceWorkerRegistrar } from "@/components/ServiceWorkerRegistrar";
 import { EnvValidationWrapper } from "@/components/EnvValidationWrapper";
 import { cn } from "@/lib/utils";
 import { AppLayoutErrorBoundary } from "@/components/layout/AppLayoutErrorBoundary";
+import { NetworkBanner } from "@/components/NetworkBanner";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -102,6 +103,7 @@ export default function RootLayout({
                 {/* Main Shell */}
                 <div className="relative flex flex-1 flex-col lg:pl-64">
                   <Navbar />
+                  <NetworkBanner />
                   <main id="main-content" className="flex-1" tabIndex={-1}>
                     <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
                       {children}

--- a/frontend/src/components/NetworkBanner.tsx
+++ b/frontend/src/components/NetworkBanner.tsx
@@ -1,21 +1,35 @@
-import React, { useState } from "react";
+"use client";
 
-const supportedChains = ["mainnet", "testnet", "devnet"];
+import { useState } from "react";
+import { X } from "lucide-react";
+import { useSettingsStore } from "@/hooks/useSettings";
 
-export function NetworkBanner({ network }: { network: string }) {
-  const [hidden, setHidden] = useState(false);
+/**
+ * Renders once in the app shell when the active network is not mainnet.
+ * Dismissible per session. Does not duplicate the network indicator in the Navbar.
+ */
+export function NetworkBanner() {
+  const [dismissed, setDismissed] = useState(false);
+  const networkMode = useSettingsStore((s) => s.settings.network.mode);
 
-  if (hidden) return null;
-  if (!supportedChains.includes(network)) {
-    return <div>Unsupported network</div>;
-  }
-  if (network === "mainnet") return null;
+  if (dismissed || networkMode === "mainnet") return null;
 
   return (
-    <div className="bg-yellow-500 text-black p-2 flex items-center justify-between">
-      <span>You are on {network}. Switch to mainnet for real swaps.</span>
-      <button className="ml-4 underline" onClick={() => setHidden(true)}>
-        Dismiss
+    <div
+      role="status"
+      aria-live="polite"
+      className="sticky top-16 z-30 flex items-center justify-between border-b border-yellow-500/30 bg-yellow-500/10 px-4 py-2 text-sm"
+    >
+      <span className="text-yellow-800 dark:text-yellow-300">
+        You are on <strong>{networkMode}</strong>. Transactions here are not real — switch to
+        mainnet for live swaps.
+      </span>
+      <button
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss network banner"
+        className="ml-4 rounded p-0.5 text-yellow-800 transition hover:bg-yellow-500/20 dark:text-yellow-300"
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
       </button>
     </div>
   );

--- a/frontend/src/components/layout/MobileNavDrawer.tsx
+++ b/frontend/src/components/layout/MobileNavDrawer.tsx
@@ -9,6 +9,7 @@ import { CommandPalette } from "./CommandPalette";
 import { NAV_LINKS } from "./navigation";
 import { useI18n } from "@/components/i18n/I18nProvider";
 import { useSettingsStore } from "@/hooks/useSettings";
+import { useIsAdmin } from "@/hooks/useIsAdmin";
 import { SUPPORTED_LOCALES, stripLocaleFromPathname } from "@/lib/i18n/config";
 import { usePathname, useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
@@ -24,6 +25,7 @@ export function MobileNavDrawer({ open, onClose }: MobileNavDrawerProps) {
   const normalizedPathname = stripLocaleFromPathname(pathname);
   const { t, localizePath } = useI18n();
   const networkMode = useSettingsStore((s) => s.settings.network.mode);
+  const isAdmin = useIsAdmin();
 
   const header = (
     <div className="flex items-center justify-between border-b border-border px-5 py-4">
@@ -95,7 +97,7 @@ export function MobileNavDrawer({ open, onClose }: MobileNavDrawerProps) {
     >
       <nav aria-label="Mobile navigation links">
         <ul className="space-y-1" role="list">
-          {NAV_LINKS.map((link) => {
+          {NAV_LINKS.filter((link) => link.href !== "/admin" || isAdmin).map((link) => {
             const active = normalizedPathname === link.href;
             return (
               <li key={link.href}>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -8,11 +8,13 @@ import { NAV_LINKS } from "./navigation";
 import { Layers, ChevronRight } from "lucide-react";
 import { stripLocaleFromPathname } from "@/lib/i18n/config";
 import { shouldPrefetch } from "@/lib/prefetch";
+import { useIsAdmin } from "@/hooks/useIsAdmin";
 
 export function Sidebar() {
   const pathname = usePathname();
   const normalizedPathname = stripLocaleFromPathname(pathname);
   const { t, localizePath } = useI18n();
+  const isAdmin = useIsAdmin();
 
   return (
     <aside className="fixed left-0 top-0 hidden h-screen w-64 flex-col border-r border-border bg-surface-raised transition-all lg:flex z-50">
@@ -32,7 +34,7 @@ export function Sidebar() {
       {/* Sidebar Navigation */}
       <nav className="flex-1 overflow-y-auto py-6 px-3 no-scrollbar" aria-label="Main Navigation">
         <ul className="space-y-1.5" role="list">
-          {NAV_LINKS.map((link) => {
+          {NAV_LINKS.filter((link) => link.href !== "/admin" || isAdmin).map((link) => {
             const isActive = normalizedPathname === link.href;
             return (
               <li key={link.href}>

--- a/frontend/src/hooks/useIsAdmin.ts
+++ b/frontend/src/hooks/useIsAdmin.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getAdminApiKey } from "@/lib/adminApi";
+
+/** Returns true when a verified admin key is stored in localStorage. */
+export function useIsAdmin(): boolean {
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    setIsAdmin(getAdminApiKey() !== null);
+  }, []);
+
+  return isAdmin;
+}


### PR DESCRIPTION
## Summary

Closes #401 
Closes #402
Closes #406
Closes #410
### Issue #401 — Replace dashboard placeholder profile with wallet summary
- New **Wallet Summary** card on the dashboard shows connected wallet address (real, from `useWalletStore`), active network mode, and total swap count.
- Removed the hardcoded `0x123...abc` placeholder entirely.

### Issue #402 — Remove duplicate Save Changes action from dashboard
- A single **Save Changes** button lives inside the Profile section only.
- Button is disabled until the user has actually changed Display Name or Email.
- On save, a success toast fires via `useToast`.

### Issue #406 — Add global network banner placement rules
- `NetworkBanner` is now a self-contained `"use client"` component that reads the active network from `useSettingsStore` — no prop needed.
- Rendered **once** in the root app shell (`layout.tsx`), positioned below the Navbar, so it never duplicates with Navbar/sidebar status copy.
- Banner is dismissible per session and hidden entirely on `mainnet`.

### Issue #410 — Hide admin navigation for non-admin users
- New `useIsAdmin` hook checks whether a verified admin API key is stored in localStorage.
- `Sidebar` and `MobileNavDrawer` filter out the `/admin` nav link for non-admin users.
- Direct `/admin` URL access still goes through the existing `AdminLoginGate`.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/hooks/useIsAdmin.ts` | New hook — localStorage admin-key check |
| `frontend/src/components/layout/Sidebar.tsx` | Filter `/admin` for non-admins |
| `frontend/src/components/layout/MobileNavDrawer.tsx` | Filter `/admin` for non-admins |
| `frontend/src/components/NetworkBanner.tsx` | Self-contained client component using settings store |
| `frontend/src/app/layout.tsx` | Mount `NetworkBanner` in app shell |
| `frontend/src/app/dashboard/page.tsx` | Wallet summary card + single save action |

## Test plan

- [ ] Non-admin user does not see **Admin** in the sidebar or mobile nav; direct `/admin` still shows login gate.
- [ ] Admin user (with valid `cb_admin_api_key` in localStorage) sees **Admin** in nav.
- [ ] Network banner appears on `testnet`/`devnet`, is dismissible, and is absent on `mainnet`.
- [ ] Banner does not duplicate the network indicator in the Navbar.
- [ ] Dashboard Wallet Summary shows real address when wallet connected, "Not connected" otherwise.
- [ ] Network mode and swap count display correctly.
- [ ] Save Changes button is disabled with empty/unchanged fields; enables on edit; fires success toast.

