### PR TITLE
All four issues (#427, #441, #443, #474) are fully implemented

### DIFF
--- a/backend/app/services/fee_estimation.py
+++ b/backend/app/services/fee_estimation.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -22,6 +25,7 @@ class FeeEstimate:
     asset: str
     components: list[FeeComponent]
     estimated_at: str
+    warning: Optional[str] = None
 
     def to_dict(self) -> dict:
         return {
@@ -38,6 +42,7 @@ class FeeEstimate:
                 for c in self.components
             ],
             "estimated_at": self.estimated_at,
+            "warning": self.warning,
         }
 
 
@@ -123,12 +128,15 @@ class FeeEstimationService:
         chain_lower = chain.lower()
         config = CHAIN_FEE_CONFIG.get(chain_lower)
         if not config:
+            msg = f"Chain '{chain_lower}' is not supported for fee estimation."
+            logger.warning(msg)
             return FeeEstimate(
                 chain=chain_lower,
                 total_fee=0.0,
                 asset="UNKNOWN",
                 components=[],
                 estimated_at=datetime.now(timezone.utc).isoformat(),
+                warning=msg,
             )
 
         network_fee = FeeComponent(

--- a/backend/app/services/price_oracle.py
+++ b/backend/app/services/price_oracle.py
@@ -26,6 +26,8 @@ DEFAULT_PRICES: dict[str, float] = {
 PRICE_CACHE_TTL = 60
 # Maximum acceptable deviation between sources (10%)
 MAX_PRICE_DEVIATION = 0.10
+# Maximum price history entries retained per asset
+MAX_HISTORY_PER_ASSET = 500
 
 
 @dataclass
@@ -260,5 +262,12 @@ class PriceOracleService:
                 timestamp=price_data.timestamp,
             )
         )
+        # Per-asset cap: remove oldest entries for this asset when over limit
+        asset_indices = [i for i, e in enumerate(self._history) if e.asset == price_data.asset]
+        if len(asset_indices) > MAX_HISTORY_PER_ASSET:
+            to_remove = len(asset_indices) - MAX_HISTORY_PER_ASSET
+            for i in reversed(asset_indices[:to_remove]):
+                self._history.pop(i)
+        # Global cap
         if len(self._history) > 5000:
             self._history = self._history[-5000:]

--- a/backend/tests/test_fee_estimation.py
+++ b/backend/tests/test_fee_estimation.py
@@ -41,6 +41,8 @@ class TestChainFeeEstimation:
         assert estimate.chain == "unknown"
         assert estimate.total_fee == 0.0
         assert len(estimate.components) == 0
+        assert estimate.warning is not None
+        assert "not supported" in estimate.warning
 
     def test_fee_components_structure(self, service):
         estimate = service.estimate_chain_fee("stellar")

--- a/backend/tests/test_price_oracle.py
+++ b/backend/tests/test_price_oracle.py
@@ -118,6 +118,23 @@ class TestPriceHistory:
             history = service.get_price_history(asset="XLM")
             assert all(r["asset"] == "XLM" for r in history)
 
+    @pytest.mark.anyio
+    async def test_per_asset_history_is_bounded(self, service):
+        from app.services.price_oracle import MAX_HISTORY_PER_ASSET, PriceHistoryEntry
+
+        for _ in range(MAX_HISTORY_PER_ASSET + 10):
+            service._history.append(
+                PriceHistoryEntry(
+                    asset="XLM", price_usd=0.15, source="test", timestamp="t"
+                )
+            )
+
+        with patch.object(service, "_fetch_coingecko", return_value=0.15):
+            await service.get_price("XLM")
+
+        xlm_count = sum(1 for e in service._history if e.asset == "XLM")
+        assert xlm_count <= MAX_HISTORY_PER_ASSET
+
 
 class TestAlerts:
     @pytest.mark.anyio

--- a/frontend/e2e/swap-smoke.spec.ts
+++ b/frontend/e2e/swap-smoke.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Happy-path smoke test for the swap form at /swap.
+ * No real wallet required — verifies UI state without wallet dependency.
+ * Issue #427
+ */
+
+const SWAP_PAGE = "/swap";
+
+test.describe("Swap form — happy-path smoke (no wallet)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(SWAP_PAGE);
+  });
+
+  test("page renders form heading", async ({ page }) => {
+    await expect(page.getByText("Create Swap")).toBeVisible();
+  });
+
+  test("From and To chain-asset selectors are visible", async ({ page }) => {
+    await expect(page.getByText("From").first()).toBeVisible();
+    await expect(page.getByText("To").first()).toBeVisible();
+  });
+
+  test("default route shows stellar XLM as source and bitcoin BTC as destination", async ({
+    page,
+  }) => {
+    // ChainAssetSelector renders the selected asset symbol as button text
+    await expect(page.getByRole("button", { name: /XLM/i }).first()).toBeVisible();
+    await expect(page.getByRole("button", { name: /BTC/i }).first()).toBeVisible();
+  });
+
+  test("amount input accepts a numeric value", async ({ page }) => {
+    const amountInput = page.locator('input[type="number"]').first();
+    await expect(amountInput).toBeVisible();
+    await amountInput.fill("10");
+    await expect(amountInput).toHaveValue("10");
+  });
+
+  test("submit button is disabled when no wallet is connected", async ({ page }) => {
+    const submit = page.getByRole("button", { name: /Connect Wallet to Swap/i });
+    await expect(submit).toBeVisible();
+    await expect(submit).toBeDisabled();
+  });
+
+  test("wallet-connect hint is visible when no wallet connected", async ({ page }) => {
+    await expect(page.getByText("Connect a wallet to continue.")).toBeVisible();
+  });
+
+  test("submit remains disabled after entering a valid amount with no wallet", async ({ page }) => {
+    await page.locator('input[type="number"]').first().fill("5");
+    // isConnected is always false in a no-wallet test — canSubmit stays false
+    const submit = page.getByRole("button", { name: /Connect Wallet to Swap/i });
+    await expect(submit).toBeDisabled();
+  });
+});

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SMARTCONTRACT_DIR="${SCRIPT_DIR}/../smartcontract"
+RELAYER_DIR="${SCRIPT_DIR}/../relayer"
 
 # ---------------------------------------------------------------------------
 # Static analysis: run cargo clippy on the smart contract
@@ -33,6 +34,18 @@ fi
 (cd "${SMARTCONTRACT_DIR}" && cargo clippy -- -D warnings)
 echo "  PASS  cargo clippy passed"
 echo ""
+
+# ---------------------------------------------------------------------------
+# Static analysis: run cargo clippy on the relayer
+# ---------------------------------------------------------------------------
+echo "============================================"
+echo "Running cargo clippy on relayer"
+echo "============================================"
+
+(cd "${RELAYER_DIR}" && cargo clippy -- -D warnings)
+echo "  PASS  cargo clippy passed (relayer)"
+echo ""
+
 CONFIG_FILE="${SCRIPT_DIR}/config/testnet.env"
 CONTRACT_ID=""
 


### PR DESCRIPTION
  ## Summary

  - Add Playwright smoke test for happy-path swap form without wallet dependency
  - Cap price history per-asset at 500 entries in addition to the existing global 5000 cap
  - Log and surface an explicit warning when fee estimation is requested for an unsupported chain
  - Run `cargo clippy` on the relayer in `scripts/verify.sh`

  ## Changes

  ### `frontend/e2e/swap-smoke.spec.ts` (new)
  Seven smoke tests cover: page heading, From/To selector visibility, default XLM→BTC route, amount input,
  disabled submit with no wallet, wallet-connect hint, and submit staying disabled after amount entry.

  ### `backend/app/services/price_oracle.py`
  Added `MAX_HISTORY_PER_ASSET = 500` constant. `_record_history` now prunes per-asset before applying the global
  5000 cap.

  ### `backend/tests/test_price_oracle.py`
  New `test_per_asset_history_is_bounded` verifies pruning removes excess entries for a single asset.

  ### `backend/app/services/fee_estimation.py`
  Added `import logging`, `logger`, and `warning: Optional[str] = None` field on `FeeEstimate`. Unsupported
  chains now log a warning and set `estimate.warning` with the message `"Chain '...' is not supported for fee
  estimation."`.

  ### `backend/tests/test_fee_estimation.py`
  `test_estimate_unknown_chain` extended to assert `warning` is set and contains `"not supported"`.

  ### `scripts/verify.sh`
  Added `RELAYER_DIR` variable and a second clippy block that runs `cargo clippy -- -D warnings` on the relayer.
  `set -euo pipefail` ensures non-zero exit on clippy failure.

  ## Closes

  Closes #427
  Closes #441
  Closes #443
  Closes #474