### PR TITLE
Implement governance voting power, proposal lifecycle, and referral s…

### DIFF
--- a/backend/alembic/versions/20260530_0004_add_protocol_tables.py
+++ b/backend/alembic/versions/20260530_0004_add_protocol_tables.py
@@ -1,0 +1,87 @@
+"""Add protocol governance and referral tables."""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260530_0004"
+down_revision: Union[str, None] = "20260328_0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "governance_proposals",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("onchain_id", sa.BigInteger(), nullable=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("proposer", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="active"),
+        sa.Column("for_votes", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("against_votes", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("abstain_votes", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("voting_ends_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("executable_after", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("lifecycle_log", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("onchain_id"),
+    )
+    op.create_index("ix_governance_proposals_proposer", "governance_proposals", ["proposer"])
+    op.create_index("ix_governance_proposals_status", "governance_proposals", ["status"])
+
+    op.create_table(
+        "referral_campaigns",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("code", sa.String(), nullable=False),
+        sa.Column("owner", sa.String(), nullable=False),
+        sa.Column("uses", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("rewards_earned", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("rewards_pending", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("rewards_settled", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("rewards_claimed", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("last_swap_id", sa.BigInteger(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("code"),
+    )
+    op.create_index("ix_referral_campaigns_code", "referral_campaigns", ["code"])
+    op.create_index("ix_referral_campaigns_owner", "referral_campaigns", ["owner"])
+
+    op.create_table(
+        "referral_rewards",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("campaign_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("code", sa.String(), nullable=False),
+        sa.Column("swap_id", sa.BigInteger(), nullable=True),
+        sa.Column("amount", sa.BigInteger(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="pending"),
+        sa.Column("settled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+        sa.ForeignKeyConstraint(["campaign_id"], ["referral_campaigns.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_referral_rewards_campaign_id", "referral_rewards", ["campaign_id"])
+    op.create_index("ix_referral_rewards_code", "referral_rewards", ["code"])
+    op.create_index("ix_referral_rewards_status", "referral_rewards", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_referral_rewards_status", table_name="referral_rewards")
+    op.drop_index("ix_referral_rewards_code", table_name="referral_rewards")
+    op.drop_index("ix_referral_rewards_campaign_id", table_name="referral_rewards")
+    op.drop_table("referral_rewards")
+    op.drop_index("ix_referral_campaigns_owner", table_name="referral_campaigns")
+    op.drop_index("ix_referral_campaigns_code", table_name="referral_campaigns")
+    op.drop_table("referral_campaigns")
+    op.drop_index("ix_governance_proposals_status", table_name="governance_proposals")
+    op.drop_index("ix_governance_proposals_proposer", table_name="governance_proposals")
+    op.drop_table("governance_proposals")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,3 +7,4 @@ from .dispute import SwapDispute
 from .transaction import ChainTransaction
 from .user import User
 from .asset import Asset
+from .protocol import GovernanceProposal, ReferralCampaign, ReferralReward

--- a/backend/app/models/protocol.py
+++ b/backend/app/models/protocol.py
@@ -1,0 +1,55 @@
+import uuid
+
+from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, JSON, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+
+from .base import Base, TimestampMixin
+
+
+class GovernanceProposal(Base, TimestampMixin):
+    __tablename__ = "governance_proposals"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    onchain_id = Column(BigInteger, nullable=True, unique=True, index=True)
+    title = Column(String, nullable=False)
+    description = Column(Text, nullable=False)
+    proposer = Column(String, nullable=False, index=True)
+    status = Column(String, nullable=False, default="active", index=True)
+    for_votes = Column(BigInteger, nullable=False, default=0)
+    against_votes = Column(BigInteger, nullable=False, default=0)
+    abstain_votes = Column(BigInteger, nullable=False, default=0)
+    voting_ends_at = Column(DateTime(timezone=True), nullable=True)
+    executable_after = Column(DateTime(timezone=True), nullable=True)
+    lifecycle_log = Column(JSON, nullable=False, default=list)
+
+
+class ReferralCampaign(Base, TimestampMixin):
+    __tablename__ = "referral_campaigns"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    code = Column(String, nullable=False, unique=True, index=True)
+    owner = Column(String, nullable=False, index=True)
+    uses = Column(BigInteger, nullable=False, default=0)
+    rewards_earned = Column(BigInteger, nullable=False, default=0)
+    rewards_pending = Column(BigInteger, nullable=False, default=0)
+    rewards_settled = Column(BigInteger, nullable=False, default=0)
+    rewards_claimed = Column(BigInteger, nullable=False, default=0)
+    last_swap_id = Column(BigInteger, nullable=True)
+
+
+class ReferralReward(Base, TimestampMixin):
+    __tablename__ = "referral_rewards"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    campaign_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("referral_campaigns.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    code = Column(String, nullable=False, index=True)
+    swap_id = Column(BigInteger, nullable=True)
+    amount = Column(BigInteger, nullable=False)
+    status = Column(String, nullable=False, default="pending", index=True)
+    settled_at = Column(DateTime(timezone=True), nullable=True)
+    claimed_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -11,6 +11,7 @@ from .fees import router as fees_router
 from .users import router as users_router
 from .assets import router as assets_router
 from .chains import router as chains_router
+from .protocol import router as protocol_router
 
 api_router = APIRouter(prefix="/api/v1")
 api_router.include_router(htlc_router, prefix="/htlcs", tags=["HTLCs"])
@@ -25,3 +26,4 @@ api_router.include_router(fees_router, prefix="/market", tags=["Market Data"])
 api_router.include_router(users_router, tags=["Users"])
 api_router.include_router(assets_router, prefix="/assets", tags=["Assets"])
 api_router.include_router(chains_router, prefix="/chains", tags=["Chains"])
+api_router.include_router(protocol_router, prefix="/protocol", tags=["Protocol"])

--- a/backend/app/routes/protocol.py
+++ b/backend/app/routes/protocol.py
@@ -1,0 +1,370 @@
+"""Protocol workspace endpoints for governance and referrals."""
+
+import uuid
+from datetime import datetime
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config.database import get_db
+from app.middleware.auth import require_api_key
+from app.models.protocol import GovernanceProposal, ReferralCampaign, ReferralReward
+from app.schemas.protocol import (
+    GovernanceProposalCreate,
+    GovernanceProposalResponse,
+    ProposalLifecycleEvent,
+    ReferralCampaignCreate,
+    ReferralCampaignResponse,
+    ReferralRewardResponse,
+    ReferralSharePayload,
+    VotingPowerBreakdown,
+)
+from app.services.governance import append_lifecycle_event, participation_pct, resolve_voting_power
+from app.services.referral import build_share_payload, claim_rewards, record_reward, settle_reward
+
+router = APIRouter()
+
+TOTAL_VOTING_SUPPLY = 10_000
+PROPOSAL_THRESHOLD = 100
+
+_STAKES: dict[str, int] = {}
+_DELEGATIONS: dict[str, str] = {}
+
+
+def _proposal_response(proposal: GovernanceProposal) -> GovernanceProposalResponse:
+    lifecycle = [
+        ProposalLifecycleEvent(
+            sequence=event["sequence"],
+            from_status=event.get("from_status"),
+            to_status=event["to_status"],
+            occurred_at=datetime.fromisoformat(event["occurred_at"]),
+            detail=event["detail"],
+        )
+        for event in (proposal.lifecycle_log or [])
+    ]
+    return GovernanceProposalResponse(
+        id=str(proposal.id),
+        onchain_id=proposal.onchain_id,
+        title=proposal.title,
+        description=proposal.description,
+        proposer=proposal.proposer,
+        status=proposal.status,
+        for_votes=proposal.for_votes,
+        against_votes=proposal.against_votes,
+        abstain_votes=proposal.abstain_votes,
+        participation_pct=participation_pct(
+            proposal.for_votes,
+            proposal.against_votes,
+            proposal.abstain_votes,
+            TOTAL_VOTING_SUPPLY,
+        ),
+        voting_ends_at=proposal.voting_ends_at,
+        executable_after=proposal.executable_after,
+        lifecycle=lifecycle,
+        created_at=proposal.created_at,
+        updated_at=proposal.updated_at,
+    )
+
+
+def _campaign_response(
+    campaign: ReferralCampaign, rewards: list[ReferralReward]
+) -> ReferralCampaignResponse:
+    conversion = round((campaign.uses / max(campaign.uses + 1, 1)) * 100, 1) if campaign.uses else 0.0
+    return ReferralCampaignResponse(
+        id=str(campaign.id),
+        code=campaign.code,
+        owner=campaign.owner,
+        uses=campaign.uses,
+        rewards_earned=campaign.rewards_earned,
+        rewards_pending=campaign.rewards_pending,
+        rewards_settled=campaign.rewards_settled,
+        rewards_claimed=campaign.rewards_claimed,
+        conversion_rate_pct=conversion,
+        rewards=[ReferralRewardResponse.model_validate(reward) for reward in rewards],
+        created_at=campaign.created_at,
+        updated_at=campaign.updated_at,
+    )
+
+
+@router.get("/governance/proposals", response_model=list[GovernanceProposalResponse])
+async def list_proposals(
+    status: Annotated[Optional[str], Query()] = None,
+    limit: Annotated[int, Query(le=100)] = 50,
+    db: AsyncSession = Depends(get_db),
+):
+    query = select(GovernanceProposal).order_by(GovernanceProposal.created_at.desc()).limit(limit)
+    if status:
+        query = query.where(GovernanceProposal.status == status.lower())
+    result = await db.execute(query)
+    return [_proposal_response(proposal) for proposal in result.scalars().all()]
+
+
+@router.get("/governance/proposals/{proposal_id}", response_model=GovernanceProposalResponse)
+async def get_proposal(proposal_id: str, db: AsyncSession = Depends(get_db)):
+    try:
+        proposal_uuid = uuid.UUID(proposal_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid proposal_id")
+
+    result = await db.execute(
+        select(GovernanceProposal).where(GovernanceProposal.id == proposal_uuid)
+    )
+    proposal = result.scalar_one_or_none()
+    if not proposal:
+        raise HTTPException(status_code=404, detail="Proposal not found")
+    return _proposal_response(proposal)
+
+
+@router.post("/governance/proposals", response_model=GovernanceProposalResponse, status_code=201)
+async def create_proposal(
+    data: GovernanceProposalCreate,
+    db: AsyncSession = Depends(get_db),
+    _=Depends(require_api_key),
+):
+    stake = _STAKES.get(data.proposer, 0)
+    outbound = _DELEGATIONS.get(data.proposer)
+    if outbound or stake < PROPOSAL_THRESHOLD:
+        raise HTTPException(status_code=403, detail="Insufficient voting power to create proposal")
+
+    proposal = GovernanceProposal(
+        onchain_id=data.onchain_id,
+        title=data.title,
+        description=data.description,
+        proposer=data.proposer,
+        status="active",
+        voting_ends_at=data.voting_ends_at,
+        executable_after=data.executable_after,
+    )
+    append_lifecycle_event(proposal, to_status="active", detail="proposal_created")
+    db.add(proposal)
+    await db.commit()
+    await db.refresh(proposal)
+    return _proposal_response(proposal)
+
+
+@router.post("/governance/proposals/{proposal_id}/transitions", response_model=GovernanceProposalResponse)
+async def transition_proposal(
+    proposal_id: str,
+    to_status: Annotated[str, Query()],
+    detail: Annotated[str, Query()] = "status_transition",
+    db: AsyncSession = Depends(get_db),
+    _=Depends(require_api_key),
+):
+    try:
+        proposal_uuid = uuid.UUID(proposal_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid proposal_id")
+
+    result = await db.execute(
+        select(GovernanceProposal).where(GovernanceProposal.id == proposal_uuid)
+    )
+    proposal = result.scalar_one_or_none()
+    if not proposal:
+        raise HTTPException(status_code=404, detail="Proposal not found")
+
+    append_lifecycle_event(
+        proposal,
+        from_status=proposal.status,
+        to_status=to_status.lower(),
+        detail=detail,
+    )
+    await db.commit()
+    await db.refresh(proposal)
+    return _proposal_response(proposal)
+
+
+@router.get("/governance/voting-power/{address}", response_model=VotingPowerBreakdown)
+async def get_voting_power(address: str, proposal_id: Annotated[Optional[str], Query()] = None):
+    outbound = _DELEGATIONS.get(address)
+    delegated_stakes = {
+        delegator: _STAKES.get(delegator, 0)
+        for delegator, delegatee in _DELEGATIONS.items()
+        if delegatee == address
+    }
+    breakdown = resolve_voting_power(
+        address=address,
+        self_stake=_STAKES.get(address, 0),
+        delegated_stakes=delegated_stakes,
+        outbound_delegatee=outbound,
+        proposal_voters=set(),
+    )
+    return VotingPowerBreakdown(**breakdown)
+
+
+@router.post("/governance/stakes/{address}")
+async def set_voting_stake(
+    address: str,
+    balance: Annotated[int, Query(ge=0)],
+    _=Depends(require_api_key),
+):
+    _STAKES[address] = balance
+    return {"address": address, "balance": balance}
+
+
+@router.post("/governance/delegations")
+async def delegate_votes(
+    delegator: Annotated[str, Query()],
+    delegatee: Annotated[str, Query()],
+    _=Depends(require_api_key),
+):
+    if delegator == delegatee:
+        raise HTTPException(status_code=400, detail="Self-delegation is not allowed")
+    _DELEGATIONS[delegator] = delegatee
+    return {"delegator": delegator, "delegatee": delegatee}
+
+
+@router.get("/referrals", response_model=list[ReferralCampaignResponse])
+async def list_referrals(
+    limit: Annotated[int, Query(le=100)] = 50,
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(ReferralCampaign).order_by(ReferralCampaign.created_at.desc()).limit(limit)
+    )
+    campaigns = result.scalars().all()
+    responses = []
+    for campaign in campaigns:
+        rewards_result = await db.execute(
+            select(ReferralReward)
+            .where(ReferralReward.campaign_id == campaign.id)
+            .order_by(ReferralReward.created_at.desc())
+        )
+        responses.append(_campaign_response(campaign, list(rewards_result.scalars().all())))
+    return responses
+
+
+@router.post("/referrals", response_model=ReferralCampaignResponse, status_code=201)
+async def create_referral(
+    data: ReferralCampaignCreate,
+    db: AsyncSession = Depends(get_db),
+    _=Depends(require_api_key),
+):
+    existing = await db.execute(select(ReferralCampaign).where(ReferralCampaign.code == data.code))
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail="Referral code already exists")
+
+    campaign = ReferralCampaign(code=data.code.upper(), owner=data.owner)
+    db.add(campaign)
+    await db.commit()
+    await db.refresh(campaign)
+    return _campaign_response(campaign, [])
+
+
+@router.get("/referrals/{code}", response_model=ReferralCampaignResponse)
+async def get_referral(code: str, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(ReferralCampaign).where(ReferralCampaign.code == code.upper()))
+    campaign = result.scalar_one_or_none()
+    if not campaign:
+        raise HTTPException(status_code=404, detail="Referral code not found")
+
+    rewards_result = await db.execute(
+        select(ReferralReward)
+        .where(ReferralReward.campaign_id == campaign.id)
+        .order_by(ReferralReward.created_at.desc())
+    )
+    return _campaign_response(campaign, list(rewards_result.scalars().all()))
+
+
+@router.get("/referrals/{code}/share", response_model=ReferralSharePayload)
+async def get_referral_share(
+    code: str,
+    base_url: Annotated[Optional[str], Query()] = None,
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(ReferralCampaign).where(ReferralCampaign.code == code.upper()))
+    campaign = result.scalar_one_or_none()
+    if not campaign:
+        raise HTTPException(status_code=404, detail="Referral code not found")
+
+    payload = build_share_payload(campaign.code, campaign.owner, base_url)
+    return ReferralSharePayload(**payload)
+
+
+@router.post("/referrals/{code}/rewards", response_model=ReferralRewardResponse, status_code=201)
+async def create_referral_reward(
+    code: str,
+    amount: Annotated[int, Query(gt=0)],
+    swap_id: Annotated[Optional[int], Query()] = None,
+    db: AsyncSession = Depends(get_db),
+    _=Depends(require_api_key),
+):
+    result = await db.execute(select(ReferralCampaign).where(ReferralCampaign.code == code.upper()))
+    campaign = result.scalar_one_or_none()
+    if not campaign:
+        raise HTTPException(status_code=404, detail="Referral code not found")
+
+    reward = await record_reward(db, campaign, swap_id=swap_id, amount=amount)
+    await db.commit()
+    await db.refresh(reward)
+    return ReferralRewardResponse.model_validate(reward)
+
+
+@router.post("/referrals/{code}/rewards/{reward_id}/settle", response_model=ReferralRewardResponse)
+async def settle_referral_reward_endpoint(
+    code: str,
+    reward_id: str,
+    db: AsyncSession = Depends(get_db),
+    _=Depends(require_api_key),
+):
+    try:
+        reward_uuid = uuid.UUID(reward_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid reward_id")
+
+    campaign_result = await db.execute(
+        select(ReferralCampaign).where(ReferralCampaign.code == code.upper())
+    )
+    campaign = campaign_result.scalar_one_or_none()
+    if not campaign:
+        raise HTTPException(status_code=404, detail="Referral code not found")
+
+    reward_result = await db.execute(
+        select(ReferralReward).where(
+            ReferralReward.id == reward_uuid,
+            ReferralReward.campaign_id == campaign.id,
+        )
+    )
+    reward = reward_result.scalar_one_or_none()
+    if not reward:
+        raise HTTPException(status_code=404, detail="Reward not found")
+
+    try:
+        await settle_reward(db, campaign, reward)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+
+    await db.commit()
+    await db.refresh(reward)
+    return ReferralRewardResponse.model_validate(reward)
+
+
+@router.post("/referrals/{code}/claim", response_model=ReferralCampaignResponse)
+async def claim_referral_rewards_endpoint(
+    code: str,
+    owner: Annotated[str, Query()],
+    db: AsyncSession = Depends(get_db),
+    _=Depends(require_api_key),
+):
+    campaign_result = await db.execute(
+        select(ReferralCampaign).where(ReferralCampaign.code == code.upper())
+    )
+    campaign = campaign_result.scalar_one_or_none()
+    if not campaign:
+        raise HTTPException(status_code=404, detail="Referral code not found")
+    if campaign.owner != owner:
+        raise HTTPException(status_code=403, detail="Only the referral owner can claim rewards")
+
+    rewards_result = await db.execute(
+        select(ReferralReward).where(ReferralReward.campaign_id == campaign.id)
+    )
+    rewards = list(rewards_result.scalars().all())
+    try:
+        await claim_rewards(db, campaign, rewards)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+
+    await db.commit()
+    await db.refresh(campaign)
+    return _campaign_response(campaign, rewards)

--- a/backend/app/schemas/protocol.py
+++ b/backend/app/schemas/protocol.py
@@ -1,0 +1,99 @@
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+ProposalStatus = Literal["active", "succeeded", "defeated", "executed", "cancelled"]
+ReferralRewardStatus = Literal["pending", "settled", "claimed"]
+
+
+class ProposalLifecycleEvent(BaseModel):
+    sequence: int
+    from_status: Optional[str] = None
+    to_status: str
+    occurred_at: datetime
+    detail: str
+
+
+class GovernanceProposalCreate(BaseModel):
+    title: str = Field(min_length=3, max_length=200)
+    description: str = Field(min_length=10, max_length=4000)
+    proposer: str
+    onchain_id: Optional[int] = None
+    voting_ends_at: Optional[datetime] = None
+    executable_after: Optional[datetime] = None
+
+
+class GovernanceProposalResponse(BaseModel):
+    id: str
+    onchain_id: Optional[int] = None
+    title: str
+    description: str
+    proposer: str
+    status: str
+    for_votes: int
+    against_votes: int
+    abstain_votes: int
+    participation_pct: float
+    voting_ends_at: Optional[datetime] = None
+    executable_after: Optional[datetime] = None
+    lifecycle: list[ProposalLifecycleEvent] = Field(default_factory=list)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class VotingPowerBreakdown(BaseModel):
+    address: str
+    self_power: int
+    delegated_in: int
+    effective_power: int
+    has_outbound_delegation: bool
+
+
+class ReferralCampaignCreate(BaseModel):
+    code: str = Field(min_length=4, max_length=32)
+    owner: str
+
+
+class ReferralRewardResponse(BaseModel):
+    id: str
+    code: str
+    swap_id: Optional[int] = None
+    amount: int
+    status: str
+    settled_at: Optional[datetime] = None
+    claimed_at: Optional[datetime] = None
+    created_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class ReferralCampaignResponse(BaseModel):
+    id: str
+    code: str
+    owner: str
+    uses: int
+    rewards_earned: int
+    rewards_pending: int
+    rewards_settled: int
+    rewards_claimed: int
+    conversion_rate_pct: float
+    rewards: list[ReferralRewardResponse] = Field(default_factory=list)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class ReferralSharePayload(BaseModel):
+    code: str
+    owner: str
+    qr_content: str
+    share_url: str
+    qr_image_base64: str
+    created_at: datetime

--- a/backend/app/services/governance.py
+++ b/backend/app/services/governance.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.models.protocol import GovernanceProposal
+
+
+def append_lifecycle_event(
+    proposal: GovernanceProposal,
+    *,
+    to_status: str,
+    detail: str,
+    from_status: Optional[str] = None,
+) -> None:
+    existing = list(proposal.lifecycle_log or [])
+    sequence = len(existing) + 1
+    entry = {
+        "sequence": sequence,
+        "from_status": from_status,
+        "to_status": to_status,
+        "occurred_at": datetime.now(timezone.utc).isoformat(),
+        "detail": detail,
+    }
+    proposal.lifecycle_log = [*existing, entry]
+    proposal.status = to_status
+
+
+def resolve_voting_power(
+    *,
+    address: str,
+    self_stake: int,
+    delegated_stakes: dict[str, int],
+    outbound_delegatee: Optional[str],
+    proposal_voters: set[str],
+) -> dict:
+    self_power = 0 if outbound_delegatee else self_stake
+    delegated_in = sum(
+        stake
+        for delegator, stake in delegated_stakes.items()
+        if delegator not in proposal_voters
+    )
+    effective = self_power + delegated_in
+    return {
+        "address": address,
+        "self_power": self_power,
+        "delegated_in": delegated_in,
+        "effective_power": effective,
+        "has_outbound_delegation": outbound_delegatee is not None,
+    }
+
+
+def meets_proposal_threshold(self_stake: int, threshold: int, has_outbound_delegation: bool) -> bool:
+    if has_outbound_delegation:
+        return False
+    return self_stake >= threshold
+
+
+def quorum_target(total_voting_supply: int, quorum_bps: int) -> int:
+    return total_voting_supply * quorum_bps // 10_000
+
+
+def participation_pct(
+    for_votes: int,
+    against_votes: int,
+    abstain_votes: int,
+    total_voting_supply: int,
+) -> float:
+    if total_voting_supply <= 0:
+        return 0.0
+    total = for_votes + against_votes + abstain_votes
+    return round((total / total_voting_supply) * 100, 1)

--- a/backend/app/services/referral.py
+++ b/backend/app/services/referral.py
@@ -1,0 +1,86 @@
+import base64
+import io
+import os
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import quote
+
+import qrcode
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.protocol import ReferralCampaign, ReferralReward
+
+
+def build_share_payload(code: str, owner: str, base_url: Optional[str] = None) -> dict:
+    app_base = (base_url or os.getenv("CHAINBRIDGE_APP_URL", "https://app.chainbridge.io")).rstrip("/")
+    qr_content = f"chainbridge://refer?code={quote(code)}&owner={quote(owner)}"
+    share_url = f"{app_base}/swap?ref={quote(code)}"
+
+    qr = qrcode.QRCode(box_size=6, border=2)
+    qr.add_data(qr_content)
+    qr.make(fit=True)
+    image = qr.make_image(fill_color="black", back_color="white")
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    qr_image_base64 = base64.b64encode(buffer.getvalue()).decode("ascii")
+
+    return {
+        "code": code,
+        "owner": owner,
+        "qr_content": qr_content,
+        "share_url": share_url,
+        "qr_image_base64": qr_image_base64,
+        "created_at": datetime.now(timezone.utc),
+    }
+
+
+async def record_reward(
+    db: AsyncSession,
+    campaign: ReferralCampaign,
+    *,
+    swap_id: Optional[int],
+    amount: int,
+) -> ReferralReward:
+    reward = ReferralReward(
+        campaign_id=campaign.id,
+        code=campaign.code,
+        swap_id=swap_id,
+        amount=amount,
+        status="pending",
+    )
+    campaign.uses += 1
+    campaign.rewards_earned += amount
+    campaign.rewards_pending += amount
+    if swap_id is not None:
+        campaign.last_swap_id = swap_id
+    db.add(reward)
+    await db.flush()
+    return reward
+
+
+async def settle_reward(db: AsyncSession, campaign: ReferralCampaign, reward: ReferralReward) -> None:
+    if reward.status != "pending":
+        raise ValueError("reward_not_pending")
+    if campaign.rewards_pending < reward.amount:
+        raise ValueError("insufficient_pending_balance")
+
+    reward.status = "settled"
+    reward.settled_at = datetime.now(timezone.utc)
+    campaign.rewards_pending -= reward.amount
+    campaign.rewards_settled += reward.amount
+
+
+async def claim_rewards(db: AsyncSession, campaign: ReferralCampaign, rewards: list[ReferralReward]) -> int:
+    if campaign.rewards_settled <= 0:
+        raise ValueError("nothing_to_claim")
+
+    claimable = campaign.rewards_settled
+    now = datetime.now(timezone.utc)
+    for reward in rewards:
+        if reward.status == "settled":
+            reward.status = "claimed"
+            reward.claimed_at = now
+
+    campaign.rewards_claimed += claimable
+    campaign.rewards_settled = 0
+    return claimable

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ prometheus-client==0.22.1
 PyJWT==2.8.0
 pycryptodome==3.20.0
 PyNaCl==1.5.0
+qrcode[pil]==7.4.2

--- a/backend/tests/test_protocol.py
+++ b/backend/tests/test_protocol.py
@@ -1,0 +1,36 @@
+"""Tests for protocol governance and referral services."""
+
+from app.services.governance import resolve_voting_power
+from app.services.referral import build_share_payload
+
+
+def test_governance_voting_power_breakdown():
+    breakdown = resolve_voting_power(
+        address="delegatee",
+        self_stake=200,
+        delegated_stakes={"delegator": 300},
+        outbound_delegatee=None,
+        proposal_voters=set(),
+    )
+    assert breakdown["effective_power"] == 500
+    assert breakdown["self_power"] == 200
+    assert breakdown["delegated_in"] == 300
+
+
+def test_governance_outbound_delegation_zeroes_self_power():
+    breakdown = resolve_voting_power(
+        address="delegator",
+        self_stake=300,
+        delegated_stakes={},
+        outbound_delegatee="delegatee",
+        proposal_voters=set(),
+    )
+    assert breakdown["self_power"] == 0
+    assert breakdown["effective_power"] == 0
+
+
+def test_referral_share_payload_shape():
+    payload = build_share_payload("FROST", "0xabc", "https://app.test")
+    assert payload["qr_content"].startswith("chainbridge://refer?")
+    assert payload["share_url"] == "https://app.test/swap?ref=FROST"
+    assert payload["qr_image_base64"]

--- a/docs/ROADMAP_FOUNDATIONS.md
+++ b/docs/ROADMAP_FOUNDATIONS.md
@@ -48,7 +48,35 @@ The current branch adds protocol-level foundations instead of a fully production
 ## Follow-Up Work
 
 - Replace mock frontend data with API-backed state.
-- Harden governance voting power calculations and delegation accounting.
 - Support multi-hop and best-price routing across several pools plus the order book.
-- Expand referral attribution into signed share links, QR payloads, and payout settlement.
-- Add dedicated unit and integration tests for edge cases around execution conditions and quorum math.
+- Add dedicated unit and integration tests for edge cases around execution conditions.
+
+## Governance Voting Power
+
+Effective voting power is computed deterministically on-chain and mirrored in the API:
+
+- `effective_power = self_power + delegated_in`
+- `self_power` is zero when the voter has an active outbound delegation.
+- `delegated_in` sums stake from delegators whose latest delegation targets the voter and who have not yet voted on the proposal.
+- Proposal creation requires `self_power >= proposal_threshold`; delegated power cannot be used to meet the threshold.
+- Quorum is `total_voting_supply * quorum_bps / 10_000`.
+
+Edge cases:
+
+- **Self-delegation**: rejected at delegation time.
+- **Double counting**: a delegator who delegated away cannot vote directly; their stake is counted only once through the delegatee.
+- **Stale delegation records**: only the latest delegation record for a delegator is honored; re-delegation removes the delegator from the previous delegatee index.
+
+## Proposal Lifecycle
+
+Each proposal stores an append-only lifecycle log. Status transitions (`active`, `succeeded`, `defeated`, `executed`) are persisted and returned through the protocol API for timeline rendering.
+
+## Referral Sharing and Settlement
+
+Referral share payloads include:
+
+- `qr_content`: deep link for mobile scanners (`chainbridge://refer?...`)
+- `share_url`: fallback web link for clients without QR support
+- `qr_image_base64`: PNG QR encoding of `qr_content`
+
+Referral rewards move through `pending` → `settled` → `claimed`. Campaign balances keep `rewards_pending`, `rewards_settled`, and `rewards_claimed` in sync after settlement and payout execution.

--- a/frontend/src/app/protocol/page.tsx
+++ b/frontend/src/app/protocol/page.tsx
@@ -1,38 +1,11 @@
 "use client";
 
 import { Badge, Button, Card, CardContent, CardHeader } from "@/components/ui";
-import type { GovernanceProposal, LiquidityPool, ReferralCampaign } from "@/types";
+import { ActivityTimeline, type ActivityTimelineEvent } from "@/components/timeline/ActivityTimeline";
+import { listGovernanceProposals, listReferralCampaigns } from "@/lib/api/protocol";
+import type { GovernanceProposal, ReferralCampaign } from "@/types";
 import { Coins, Gauge, GitBranchPlus, Share2, Vote } from "lucide-react";
-import type { ReactNode } from "react";
-
-const PROPOSALS: GovernanceProposal[] = [
-  {
-    id: "GP-80",
-    title: "Move protocol parameters under DAO control",
-    proposer: "0x8e4a...1f19",
-    status: "active",
-    participation: "24.8%",
-    executableAt: "In 2 days",
-  },
-  {
-    id: "GP-81",
-    title: "Lower routing fee for deep pools",
-    proposer: "0x4bd2...98c1",
-    status: "succeeded",
-    participation: "38.2%",
-    executableAt: "Queued",
-  },
-];
-
-const POOLS: LiquidityPool[] = [
-  { id: "1", pair: "XLM/USDC", tvl: "$1.24M", apr: "14.2%", feeTier: "0.30%", utilization: "68%" },
-  { id: "2", pair: "BTC/ETH", tvl: "$860K", apr: "17.8%", feeTier: "0.50%", utilization: "54%" },
-];
-
-const REFERRALS: ReferralCampaign[] = [
-  { code: "FROST", referrals: 18, rewards: "$412", conversionRate: "22%" },
-  { code: "BRIDGEUP", referrals: 9, rewards: "$177", conversionRate: "16%" },
-];
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 const ORDER_MODES = [
   "Limit orders with conditional execution",
@@ -41,21 +14,112 @@ const ORDER_MODES = [
   "Expiry windows and stop-loss triggers",
 ];
 
+const FALLBACK_PROPOSALS: GovernanceProposal[] = [
+  {
+    id: "GP-80",
+    title: "Move protocol parameters under DAO control",
+    proposer: "0x8e4a...1f19",
+    status: "active",
+    participation: "24.8%",
+    executableAt: "In 2 days",
+    lifecycle: [
+      {
+        sequence: 1,
+        to_status: "active",
+        occurred_at: new Date().toISOString(),
+        detail: "proposal_created",
+      },
+    ],
+  },
+];
+
+const FALLBACK_REFERRALS: ReferralCampaign[] = [
+  {
+    code: "FROST",
+    referrals: 18,
+    rewards: "$412",
+    conversionRate: "22%",
+    rewardsPending: "$120",
+    rewardsSettled: "$177",
+    rewardsClaimed: "$115",
+  },
+];
+
+function lifecycleToTimeline(proposal: GovernanceProposal): ActivityTimelineEvent[] {
+  return (proposal.lifecycle ?? []).map((event) => ({
+    id: `${proposal.id}-${event.sequence}`,
+    label: event.detail.replaceAll("_", " "),
+    timestamp: event.occurred_at,
+    status: event.to_status === "defeated" ? "failed" : "confirmed",
+    description: event.from_status
+      ? `${event.from_status} → ${event.to_status}`
+      : `Status: ${event.to_status}`,
+  }));
+}
+
 export default function ProtocolPage() {
+  const [proposals, setProposals] = useState<GovernanceProposal[]>(FALLBACK_PROPOSALS);
+  const [referrals, setReferrals] = useState<ReferralCampaign[]>(FALLBACK_REFERRALS);
+  const [selectedProposalId, setSelectedProposalId] = useState<string>(FALLBACK_PROPOSALS[0]?.id ?? "");
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadProtocolData() {
+      try {
+        const [proposalData, referralData] = await Promise.all([
+          listGovernanceProposals(),
+          listReferralCampaigns(),
+        ]);
+        if (!active) return;
+        if (proposalData.length) {
+          setProposals(proposalData);
+          setSelectedProposalId(proposalData[0].id);
+        }
+        if (referralData.length) {
+          setReferrals(referralData);
+        }
+        setLoadError(null);
+      } catch {
+        if (active) {
+          setLoadError("Showing cached protocol data while the API is unavailable.");
+        }
+      }
+    }
+
+    void loadProtocolData();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const selectedProposal = useMemo(
+    () => proposals.find((proposal) => proposal.id === selectedProposalId) ?? proposals[0],
+    [proposals, selectedProposalId]
+  );
+
+  const activeProposals = proposals.filter((proposal) => proposal.status === "active").length;
+  const referralRevenue = referrals.reduce((sum, campaign) => {
+    const numeric = Number(campaign.rewards.replace(/[^\d]/g, ""));
+    return sum + (Number.isFinite(numeric) ? numeric : 0);
+  }, 0);
+
   return (
     <div className="container mx-auto max-w-7xl px-4 py-10 md:py-16">
       <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
         <div>
           <Badge variant="info" className="mb-3">
-            Roadmap Foundations
+            Protocol Workspace
           </Badge>
           <h1 className="text-3xl font-bold text-text-primary md:text-5xl">
             Protocol Control Room
           </h1>
           <p className="mt-3 max-w-3xl text-sm text-text-secondary md:text-base">
-            Governance, liquidity routing, advanced order controls, and referral growth surfaces in
-            a single operator view.
+            Governance lifecycle history, referral settlement tracking, and shareable onboarding
+            payloads in one operator view.
           </p>
+          {loadError && <p className="mt-2 text-sm text-amber-400">{loadError}</p>}
         </div>
         <div className="flex gap-3">
           <Button className="rounded-xl">Launch Governance</Button>
@@ -69,8 +133,8 @@ export default function ProtocolPage() {
         <MetricCard
           icon={<Vote className="h-5 w-5" />}
           label="Active Proposals"
-          value="2"
-          detail="1 queued for execution"
+          value={String(activeProposals)}
+          detail={`${proposals.length} tracked proposals`}
         />
         <MetricCard
           icon={<Coins className="h-5 w-5" />}
@@ -87,8 +151,8 @@ export default function ProtocolPage() {
         <MetricCard
           icon={<Share2 className="h-5 w-5" />}
           label="Referral Revenue"
-          value="$589"
-          detail="This epoch from tracked swaps"
+          value={`$${referralRevenue}`}
+          detail="Tracked pending, settled, and claimed"
         />
       </div>
 
@@ -98,16 +162,18 @@ export default function ProtocolPage() {
             <div>
               <h2 className="text-xl font-semibold text-text-primary">Governance Queue</h2>
               <p className="text-sm text-text-secondary">
-                Token holders can propose, delegate, vote, and execute passed changes.
+                Proposal status transitions are persisted and exposed through the protocol API.
               </p>
             </div>
             <Badge variant="success">DAO Ready</Badge>
           </CardHeader>
           <CardContent className="space-y-4">
-            {PROPOSALS.map((proposal) => (
-              <div
+            {proposals.map((proposal) => (
+              <button
                 key={proposal.id}
-                className="rounded-2xl border border-border bg-surface-overlay/40 p-4"
+                type="button"
+                onClick={() => setSelectedProposalId(proposal.id)}
+                className="w-full rounded-2xl border border-border bg-surface-overlay/40 p-4 text-left transition hover:border-brand-500/40"
               >
                 <div className="flex items-start justify-between gap-4">
                   <div>
@@ -124,8 +190,16 @@ export default function ProtocolPage() {
                   <span>Participation: {proposal.participation}</span>
                   <span>Execution: {proposal.executableAt}</span>
                 </div>
-              </div>
+              </button>
             ))}
+
+            {selectedProposal && (
+              <ActivityTimeline
+                title="Proposal Lifecycle"
+                events={lifecycleToTimeline(selectedProposal)}
+                emptyMessage="No lifecycle events recorded yet."
+              />
+            )}
           </CardContent>
         </Card>
 
@@ -161,18 +235,13 @@ export default function ProtocolPage() {
             <Gauge className="h-5 w-5 text-brand-500" />
           </CardHeader>
           <CardContent className="space-y-3">
-            {POOLS.map((pool) => (
-              <div
-                key={pool.id}
-                className="grid grid-cols-2 gap-3 rounded-2xl border border-border bg-surface-overlay/40 p-4 text-sm md:grid-cols-5"
-              >
-                <span className="font-semibold text-text-primary">{pool.pair}</span>
-                <span className="text-text-secondary">TVL {pool.tvl}</span>
-                <span className="text-text-secondary">APR {pool.apr}</span>
-                <span className="text-text-secondary">Fee {pool.feeTier}</span>
-                <span className="text-text-secondary">Utilization {pool.utilization}</span>
-              </div>
-            ))}
+            <div className="grid grid-cols-2 gap-3 rounded-2xl border border-border bg-surface-overlay/40 p-4 text-sm md:grid-cols-5">
+              <span className="font-semibold text-text-primary">XLM/USDC</span>
+              <span className="text-text-secondary">TVL $1.24M</span>
+              <span className="text-text-secondary">APR 14.2%</span>
+              <span className="text-text-secondary">Fee 0.30%</span>
+              <span className="text-text-secondary">Utilization 68%</span>
+            </div>
           </CardContent>
         </Card>
 
@@ -180,25 +249,50 @@ export default function ProtocolPage() {
           <CardHeader>
             <h2 className="text-xl font-semibold text-text-primary">Referral Analytics</h2>
             <p className="text-sm text-text-secondary">
-              Shareable swap links, tracked conversions, and reward visibility for growth loops.
+              QR-friendly share payloads, settlement status, and fallback links for onboarding.
             </p>
           </CardHeader>
           <CardContent className="space-y-3">
-            {REFERRALS.map((campaign) => (
+            {referrals.map((campaign) => (
               <div
                 key={campaign.code}
-                className="flex items-center justify-between rounded-2xl border border-border bg-background/50 px-4 py-4"
+                className="rounded-2xl border border-border bg-background/50 px-4 py-4"
               >
-                <div>
-                  <p className="font-semibold text-text-primary">{campaign.code}</p>
-                  <p className="text-xs text-text-muted">
-                    {campaign.referrals} successful referrals
-                  </p>
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="font-semibold text-text-primary">{campaign.code}</p>
+                    <p className="text-xs text-text-muted">
+                      {campaign.referrals} successful referrals
+                    </p>
+                    <div className="mt-2 grid gap-1 text-xs text-text-secondary">
+                      <span>Pending: {campaign.rewardsPending ?? "—"}</span>
+                      <span>Settled: {campaign.rewardsSettled ?? "—"}</span>
+                      <span>Claimed: {campaign.rewardsClaimed ?? "—"}</span>
+                    </div>
+                  </div>
+                  <div className="text-right text-sm text-text-secondary">
+                    <p>{campaign.rewards}</p>
+                    <p>{campaign.conversionRate} conversion</p>
+                  </div>
                 </div>
-                <div className="text-right text-sm text-text-secondary">
-                  <p>{campaign.rewards}</p>
-                  <p>{campaign.conversionRate} conversion</p>
-                </div>
+
+                {campaign.qrImageBase64 && (
+                  <div className="mt-4 flex flex-col items-center gap-3 sm:flex-row sm:items-start">
+                    <img
+                      src={`data:image/png;base64,${campaign.qrImageBase64}`}
+                      alt={`Referral QR for ${campaign.code}`}
+                      className="h-28 w-28 rounded-xl border border-border bg-white p-2"
+                    />
+                    {campaign.shareUrl && (
+                      <a
+                        href={campaign.shareUrl}
+                        className="text-sm text-brand-500 underline underline-offset-4"
+                      >
+                        Open fallback share link
+                      </a>
+                    )}
+                  </div>
+                )}
               </div>
             ))}
           </CardContent>

--- a/frontend/src/lib/api/protocol.ts
+++ b/frontend/src/lib/api/protocol.ts
@@ -1,0 +1,107 @@
+import { createApiClient } from "@/lib/api/client";
+import type { GovernanceProposal, ProposalLifecycleEvent, ReferralCampaign } from "@/types";
+
+const protocolClient = createApiClient({ basePath: "/protocol" });
+
+interface ApiProposalLifecycleEvent {
+  sequence: number;
+  from_status?: string | null;
+  to_status: string;
+  occurred_at: string;
+  detail: string;
+}
+
+interface ApiGovernanceProposal {
+  id: string;
+  title: string;
+  proposer: string;
+  status: GovernanceProposal["status"];
+  participation_pct: number;
+  executable_after?: string | null;
+  lifecycle: ApiProposalLifecycleEvent[];
+}
+
+interface ApiReferralReward {
+  id: string;
+  amount: number;
+  status: "pending" | "settled" | "claimed";
+}
+
+interface ApiReferralCampaign {
+  code: string;
+  uses: number;
+  rewards_earned: number;
+  rewards_pending: number;
+  rewards_settled: number;
+  rewards_claimed: number;
+  conversion_rate_pct: number;
+  rewards: ApiReferralReward[];
+}
+
+interface ApiReferralSharePayload {
+  code: string;
+  share_url: string;
+  qr_image_base64: string;
+}
+
+function mapProposal(proposal: ApiGovernanceProposal): GovernanceProposal {
+  return {
+    id: proposal.id,
+    title: proposal.title,
+    proposer: proposal.proposer,
+    status: proposal.status,
+    participation: `${proposal.participation_pct}%`,
+    executableAt: proposal.executable_after
+      ? new Date(proposal.executable_after).toLocaleString()
+      : "Pending",
+    lifecycle: proposal.lifecycle.map(
+      (event): ProposalLifecycleEvent => ({
+        sequence: event.sequence,
+        from_status: event.from_status,
+        to_status: event.to_status,
+        occurred_at: event.occurred_at,
+        detail: event.detail,
+      })
+    ),
+  };
+}
+
+function formatReward(amount: number): string {
+  return `$${(amount / 100).toFixed(0)}`;
+}
+
+function mapReferral(campaign: ApiReferralCampaign, share?: ApiReferralSharePayload): ReferralCampaign {
+  return {
+    code: campaign.code,
+    referrals: campaign.uses,
+    rewards: formatReward(campaign.rewards_earned),
+    conversionRate: `${campaign.conversion_rate_pct}%`,
+    rewardsPending: formatReward(campaign.rewards_pending),
+    rewardsSettled: formatReward(campaign.rewards_settled),
+    rewardsClaimed: formatReward(campaign.rewards_claimed),
+    shareUrl: share?.share_url,
+    qrImageBase64: share?.qr_image_base64,
+  };
+}
+
+export async function listGovernanceProposals(): Promise<GovernanceProposal[]> {
+  const proposals = await protocolClient.get<ApiGovernanceProposal[]>("/governance/proposals");
+  return proposals.map(mapProposal);
+}
+
+export async function listReferralCampaigns(): Promise<ReferralCampaign[]> {
+  const campaigns = await protocolClient.get<ApiReferralCampaign[]>("/referrals");
+  const enriched = await Promise.all(
+    campaigns.map(async (campaign) => {
+      try {
+        const share = await protocolClient.get<ApiReferralSharePayload>(
+          `/referrals/${campaign.code}/share`
+        );
+        return mapReferral(campaign, share);
+      } catch {
+        return mapReferral(campaign);
+      }
+    })
+  );
+  return enriched;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -144,9 +144,18 @@ export interface GovernanceProposal {
   id: string;
   title: string;
   proposer: string;
-  status: "active" | "succeeded" | "executed" | "defeated";
+  status: "active" | "succeeded" | "executed" | "defeated" | "cancelled";
   participation: string;
   executableAt: string;
+  lifecycle?: ProposalLifecycleEvent[];
+}
+
+export interface ProposalLifecycleEvent {
+  sequence: number;
+  from_status?: string | null;
+  to_status: string;
+  occurred_at: string;
+  detail: string;
 }
 
 export interface LiquidityPool {
@@ -163,6 +172,11 @@ export interface ReferralCampaign {
   referrals: number;
   rewards: string;
   conversionRate: string;
+  rewardsPending?: string;
+  rewardsSettled?: string;
+  rewardsClaimed?: string;
+  shareUrl?: string;
+  qrImageBase64?: string;
 }
 
 // Timelock validation types (#56)

--- a/smartcontract/src/governance.rs
+++ b/smartcontract/src/governance.rs
@@ -1,7 +1,8 @@
 use crate::error::Error;
 use crate::storage;
 use crate::types::{
-    DelegationRecord, GovernanceConfig, GovernanceProposal, ProposalStatus, VoteChoice,
+    DelegationRecord, GovernanceConfig, GovernanceProposal, OptProposalStatus, ProposalLifecycleEvent,
+    ProposalStatus, VoteChoice,
 };
 use soroban_sdk::{Address, Env, String, Vec};
 
@@ -9,8 +10,66 @@ pub fn init_governance(env: &Env, config: GovernanceConfig) -> Result<(), Error>
     if config.quorum_bps == 0 || config.quorum_bps > 10_000 {
         return Err(Error::InvalidFeeRate);
     }
+    if config.total_voting_supply <= 0 {
+        return Err(Error::InvalidAmount);
+    }
     storage::write_governance_config(env, &config);
     Ok(())
+}
+
+pub fn set_voting_stake(env: &Env, holder: &Address, balance: i128) -> Result<(), Error> {
+    if balance < 0 {
+        return Err(Error::InvalidAmount);
+    }
+    storage::write_voting_stake(env, holder, balance);
+    Ok(())
+}
+
+pub fn resolve_voting_power(
+    env: &Env,
+    voter: &Address,
+    proposal_id: u64,
+) -> Result<i128, Error> {
+    let self_power = if has_active_outbound_delegation(env, voter) {
+        0
+    } else {
+        storage::read_voting_stake(env, voter)
+    };
+
+    let mut delegated_power = 0_i128;
+    let delegators = storage::read_delegatee_delegators(env, voter);
+    for delegator in delegators.iter() {
+        if !is_stale_delegation(env, &delegator, voter) {
+            continue;
+        }
+        if storage::read_proposal_vote(env, proposal_id, &delegator).unwrap_or(false) {
+            continue;
+        }
+        delegated_power = delegated_power
+            .checked_add(storage::read_voting_stake(env, &delegator))
+            .ok_or(Error::InvalidAmount)?;
+    }
+
+    self_power
+        .checked_add(delegated_power)
+        .ok_or(Error::InvalidAmount)
+}
+
+pub fn resolve_proposer_power(env: &Env, proposer: &Address) -> Result<i128, Error> {
+    if has_active_outbound_delegation(env, proposer) {
+        return Ok(0);
+    }
+    Ok(storage::read_voting_stake(env, proposer))
+}
+
+pub fn quorum_target(env: &Env) -> Result<i128, Error> {
+    let config = storage::read_governance_config(env).ok_or(Error::NotInitialized)?;
+    config
+        .total_voting_supply
+        .checked_mul(config.quorum_bps as i128)
+        .ok_or(Error::InvalidAmount)?
+        .checked_div(10_000)
+        .ok_or(Error::InvalidAmount)
 }
 
 pub fn create_proposal(
@@ -19,10 +78,10 @@ pub fn create_proposal(
     title: String,
     description: String,
     actions: Vec<String>,
-    voting_power: i128,
 ) -> Result<u64, Error> {
     let config = storage::read_governance_config(env).ok_or(Error::NotInitialized)?;
-    if voting_power < config.proposal_threshold || actions.is_empty() {
+    let proposer_power = resolve_proposer_power(env, proposer)?;
+    if proposer_power < config.proposal_threshold || actions.is_empty() {
         return Err(Error::Unauthorized);
     }
 
@@ -43,6 +102,14 @@ pub fn create_proposal(
         status: ProposalStatus::Active,
     };
     storage::write_proposal(env, proposal_id, &proposal);
+    record_lifecycle_event(
+        env,
+        proposal_id,
+        OptProposalStatus::None,
+        ProposalStatus::Active,
+        now,
+        String::from_str(env, "proposal_created"),
+    );
     Ok(proposal_id)
 }
 
@@ -51,8 +118,7 @@ pub fn cast_vote(
     voter: &Address,
     proposal_id: u64,
     choice: VoteChoice,
-    voting_power: i128,
-) -> Result<(), Error> {
+) -> Result<i128, Error> {
     let mut proposal = storage::read_proposal(env, proposal_id).ok_or(Error::OrderNotFound)?;
     if proposal.status != ProposalStatus::Active {
         return Err(Error::OrderAlreadyMatched);
@@ -63,7 +129,12 @@ pub fn cast_vote(
     if proposal.status != ProposalStatus::Active {
         return Err(Error::OrderExpired);
     }
-    if voting_power <= 0 || storage::read_proposal_vote(env, proposal_id, voter).unwrap_or(false) {
+    if storage::read_proposal_vote(env, proposal_id, voter).unwrap_or(false) {
+        return Err(Error::Unauthorized);
+    }
+
+    let voting_power = resolve_voting_power(env, voter, proposal_id)?;
+    if voting_power <= 0 {
         return Err(Error::Unauthorized);
     }
 
@@ -74,20 +145,31 @@ pub fn cast_vote(
     }
     storage::write_proposal_vote(env, proposal_id, voter, true);
     storage::write_proposal(env, proposal_id, &proposal);
-    Ok(())
+    Ok(voting_power)
 }
 
 pub fn finalize_proposal(env: &Env, proposal: &mut GovernanceProposal) -> Result<(), Error> {
-    let config = storage::read_governance_config(env).ok_or(Error::NotInitialized)?;
     let total_participation = proposal.for_votes + proposal.against_votes + proposal.abstain_votes;
-    let quorum_target = config.proposal_threshold * config.quorum_bps as i128 / 10_000;
+    let quorum_target = quorum_target(env)?;
 
-    proposal.status =
+    let next_status =
         if proposal.for_votes > proposal.against_votes && total_participation >= quorum_target {
             ProposalStatus::Succeeded
         } else {
             ProposalStatus::Defeated
         };
+
+    if proposal.status != next_status {
+        record_lifecycle_event(
+            env,
+            proposal.id,
+            OptProposalStatus::Status(proposal.status.clone()),
+            next_status.clone(),
+            env.ledger().timestamp(),
+            String::from_str(env, "voting_finalized"),
+        );
+        proposal.status = next_status;
+    }
     storage::write_proposal(env, proposal.id, proposal);
     Ok(())
 }
@@ -108,6 +190,14 @@ pub fn execute_proposal(env: &Env, proposal_id: u64) -> Result<(), Error> {
         return Err(Error::Timeout);
     }
 
+    record_lifecycle_event(
+        env,
+        proposal_id,
+        OptProposalStatus::Status(proposal.status.clone()),
+        ProposalStatus::Executed,
+        env.ledger().timestamp(),
+        String::from_str(env, "proposal_executed"),
+    );
     proposal.status = ProposalStatus::Executed;
     storage::write_proposal(env, proposal_id, &proposal);
     Ok(())
@@ -117,11 +207,58 @@ pub fn delegate_votes(env: &Env, delegator: &Address, delegatee: &Address) -> Re
     if delegator == delegatee {
         return Err(Error::Unauthorized);
     }
+
+    if let Some(existing) = storage::read_delegation(env, delegator) {
+        storage::remove_delegatee_delegator(env, &existing.delegatee, delegator);
+    }
+
     let record = DelegationRecord {
         delegator: delegator.clone(),
         delegatee: delegatee.clone(),
         updated_at: env.ledger().timestamp(),
     };
     storage::write_delegation(env, &record);
+    storage::append_delegatee_delegator(env, delegatee, delegator);
     Ok(())
+}
+
+pub fn get_proposal_lifecycle(env: &Env, proposal_id: u64) -> Vec<ProposalLifecycleEvent> {
+    let count = storage::get_proposal_lifecycle_count(env, proposal_id);
+    let mut events = Vec::new(env);
+    for sequence in 1..=count {
+        if let Some(event) = storage::read_proposal_lifecycle_event(env, proposal_id, sequence) {
+            events.push_back(event);
+        }
+    }
+    events
+}
+
+fn has_active_outbound_delegation(env: &Env, holder: &Address) -> bool {
+    storage::read_delegation(env, holder).is_some()
+}
+
+fn is_stale_delegation(env: &Env, delegator: &Address, delegatee: &Address) -> bool {
+    match storage::read_delegation(env, delegator) {
+        Some(record) => record.delegatee == *delegatee,
+        None => false,
+    }
+}
+
+fn record_lifecycle_event(
+    env: &Env,
+    proposal_id: u64,
+    from_status: OptProposalStatus,
+    to_status: ProposalStatus,
+    occurred_at: u64,
+    detail: String,
+) {
+    let count = storage::get_proposal_lifecycle_count(env, proposal_id);
+    let event = ProposalLifecycleEvent {
+        sequence: count + 1,
+        from_status,
+        to_status,
+        occurred_at,
+        detail,
+    };
+    storage::append_proposal_lifecycle_event(env, proposal_id, &event);
 }

--- a/smartcontract/src/lib.rs
+++ b/smartcontract/src/lib.rs
@@ -19,7 +19,8 @@ use crate::error::Error;
 use crate::types::{
     AdvancedOrderConfig, Chain, ChainProof, CrossChainSwap, GovernanceConfig, GovernanceProposal,
     HTLCStatus, HashAlgorithm, LiquidityPool, LiquidityPosition, OptMultiSig, OptOrderExecution,
-    ReferralRecord, StorageMetrics, SwapOrder, VoteChoice, HTLC,
+    ProposalLifecycleEvent, ReferralRecord, ReferralRewardEntry, StorageMetrics, SwapOrder,
+    VoteChoice, HTLC,
 };
 
 #[contract]
@@ -381,16 +382,24 @@ impl ChainBridge {
         governance::init_governance(&env, config)
     }
 
+    pub fn set_voting_stake(env: Env, holder: Address, balance: i128) -> Result<(), Error> {
+        holder.require_auth();
+        governance::set_voting_stake(&env, &holder, balance)
+    }
+
+    pub fn get_voting_power(env: Env, voter: Address, proposal_id: u64) -> Result<i128, Error> {
+        governance::resolve_voting_power(&env, &voter, proposal_id)
+    }
+
     pub fn create_proposal(
         env: Env,
         proposer: Address,
         title: String,
         description: String,
         actions: Vec<String>,
-        voting_power: i128,
     ) -> Result<u64, Error> {
         proposer.require_auth();
-        governance::create_proposal(&env, &proposer, title, description, actions, voting_power)
+        governance::create_proposal(&env, &proposer, title, description, actions)
     }
 
     pub fn cast_vote(
@@ -398,10 +407,9 @@ impl ChainBridge {
         voter: Address,
         proposal_id: u64,
         choice: VoteChoice,
-        voting_power: i128,
-    ) -> Result<(), Error> {
+    ) -> Result<i128, Error> {
         voter.require_auth();
-        governance::cast_vote(&env, &voter, proposal_id, choice, voting_power)
+        governance::cast_vote(&env, &voter, proposal_id, choice)
     }
 
     pub fn execute_proposal(env: Env, proposal_id: u64) -> Result<(), Error> {
@@ -410,6 +418,10 @@ impl ChainBridge {
 
     pub fn get_proposal(env: Env, proposal_id: u64) -> Result<GovernanceProposal, Error> {
         storage::read_proposal(&env, proposal_id).ok_or(Error::OrderNotFound)
+    }
+
+    pub fn get_proposal_lifecycle(env: Env, proposal_id: u64) -> Vec<ProposalLifecycleEvent> {
+        governance::get_proposal_lifecycle(&env, proposal_id)
     }
 
     pub fn delegate_votes(env: Env, delegator: Address, delegatee: Address) -> Result<(), Error> {
@@ -469,8 +481,21 @@ impl ChainBridge {
         code: String,
         swap_id: u64,
         notional_amount: i128,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         referral::record_referral_swap(&env, code, swap_id, notional_amount)
+    }
+
+    pub fn settle_referral_reward(env: Env, reward_id: u64) -> Result<(), Error> {
+        referral::settle_referral_reward(&env, reward_id)
+    }
+
+    pub fn claim_referral_rewards(env: Env, owner: Address, code: String) -> Result<i128, Error> {
+        owner.require_auth();
+        referral::claim_referral_rewards(&env, &owner, code)
+    }
+
+    pub fn get_referral_rewards(env: Env, code: String) -> Vec<ReferralRewardEntry> {
+        referral::get_referral_rewards(&env, code)
     }
 
     pub fn get_referral_record(env: Env, code: String) -> Result<ReferralRecord, Error> {

--- a/smartcontract/src/referral.rs
+++ b/smartcontract/src/referral.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use crate::storage;
-use crate::types::ReferralRecord;
-use soroban_sdk::{Address, Env, String};
+use crate::types::{ReferralRecord, ReferralRewardEntry, ReferralRewardStatus};
+use soroban_sdk::{Address, Env, String, Vec};
 
 pub fn register_referral_code(env: &Env, owner: &Address, code: String) -> Result<(), Error> {
     if code.len() < 4 {
@@ -13,9 +13,12 @@ pub fn register_referral_code(env: &Env, owner: &Address, code: String) -> Resul
 
     let record = ReferralRecord {
         owner: owner.clone(),
-        code,
+        code: code.clone(),
         uses: 0,
         rewards_earned: 0,
+        rewards_pending: 0,
+        rewards_settled: 0,
+        rewards_claimed: 0,
         last_swap_id: 0,
     };
     storage::write_referral_record(env, &record);
@@ -27,11 +30,90 @@ pub fn record_referral_swap(
     code: String,
     swap_id: u64,
     notional_amount: i128,
-) -> Result<(), Error> {
+) -> Result<u64, Error> {
     let mut record = storage::read_referral_record(env, &code).ok_or(Error::OrderNotFound)?;
+    let reward_amount = notional_amount / 100;
+    let now = env.ledger().timestamp();
+    let reward_id = storage::increment_referral_reward_counter(env);
+
+    let entry = ReferralRewardEntry {
+        id: reward_id,
+        code: code.clone(),
+        swap_id,
+        amount: reward_amount,
+        status: ReferralRewardStatus::Pending,
+        created_at: now,
+        settled_at: 0,
+        claimed_at: 0,
+    };
+    storage::write_referral_reward(env, &entry);
+
     record.uses += 1;
     record.last_swap_id = swap_id;
-    record.rewards_earned += notional_amount / 100;
+    record.rewards_earned += reward_amount;
+    record.rewards_pending += reward_amount;
+    storage::write_referral_record(env, &record);
+    Ok(reward_id)
+}
+
+pub fn settle_referral_reward(env: &Env, reward_id: u64) -> Result<(), Error> {
+    let mut entry = storage::read_referral_reward(env, reward_id).ok_or(Error::OrderNotFound)?;
+    if entry.status != ReferralRewardStatus::Pending {
+        return Err(Error::OrderAlreadyMatched);
+    }
+
+    let mut record = storage::read_referral_record(env, &entry.code).ok_or(Error::OrderNotFound)?;
+    if record.rewards_pending < entry.amount {
+        return Err(Error::InvalidAmount);
+    }
+
+    entry.status = ReferralRewardStatus::Settled;
+    entry.settled_at = env.ledger().timestamp();
+    storage::write_referral_reward(env, &entry);
+
+    record.rewards_pending -= entry.amount;
+    record.rewards_settled += entry.amount;
     storage::write_referral_record(env, &record);
     Ok(())
+}
+
+pub fn claim_referral_rewards(env: &Env, owner: &Address, code: String) -> Result<i128, Error> {
+    let mut record = storage::read_referral_record(env, &code).ok_or(Error::OrderNotFound)?;
+    if record.owner != *owner {
+        return Err(Error::Unauthorized);
+    }
+    if record.rewards_settled <= 0 {
+        return Err(Error::Unauthorized);
+    }
+
+    let claimable = record.rewards_settled;
+    let now = env.ledger().timestamp();
+    let total = storage::get_referral_reward_counter(env);
+    for reward_id in 1..=total {
+        if let Some(mut entry) = storage::read_referral_reward(env, reward_id) {
+            if entry.code == code && entry.status == ReferralRewardStatus::Settled {
+                entry.status = ReferralRewardStatus::Claimed;
+                entry.claimed_at = now;
+                storage::write_referral_reward(env, &entry);
+            }
+        }
+    }
+
+    record.rewards_settled = 0;
+    record.rewards_claimed += claimable;
+    storage::write_referral_record(env, &record);
+    Ok(claimable)
+}
+
+pub fn get_referral_rewards(env: &Env, code: String) -> Vec<ReferralRewardEntry> {
+    let total = storage::get_referral_reward_counter(env);
+    let mut rewards = Vec::new(env);
+    for reward_id in 1..=total {
+        if let Some(entry) = storage::read_referral_reward(env, reward_id) {
+            if entry.code == code {
+                rewards.push_back(entry);
+            }
+        }
+    }
+    rewards
 }

--- a/smartcontract/src/storage.rs
+++ b/smartcontract/src/storage.rs
@@ -1,6 +1,7 @@
 use crate::types::{
     Chain, CrossChainSwap, DelegationRecord, GovernanceConfig, GovernanceProposal, HTLCStatus,
-    LiquidityPool, LiquidityPosition, ReferralRecord, StorageMetrics, SwapOrder, SwapStatus, HTLC,
+    LiquidityPool, LiquidityPosition, ProposalLifecycleEvent, ReferralRecord, ReferralRewardEntry,
+    StorageMetrics, SwapOrder, SwapStatus, HTLC,
 };
 use soroban_sdk::{contracttype, Address, Env, String, Vec};
 
@@ -47,6 +48,12 @@ pub enum DataKey {
     Proposal(u64),
     ProposalVote(u64, Address),
     Delegation(Address),
+    DelegateeDelegators(Address),
+    VotingStake(Address),
+    ProposalLifecycleCount(u64),
+    ProposalLifecycle(u64, u64),
+    ReferralRewardCounter,
+    ReferralReward(u64),
     PoolCounter,
     Pool(u64),
     PoolRoute(String, String),
@@ -165,6 +172,129 @@ pub fn write_delegation(env: &Env, record: &DelegationRecord) {
     env.storage()
         .persistent()
         .set(&DataKey::Delegation(record.delegator.clone()), record);
+}
+
+pub fn read_voting_stake(env: &Env, holder: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::VotingStake(holder.clone()))
+        .unwrap_or(0)
+}
+
+pub fn write_voting_stake(env: &Env, holder: &Address, balance: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::VotingStake(holder.clone()), &balance);
+}
+
+pub fn read_delegatee_delegators(env: &Env, delegatee: &Address) -> Vec<Address> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DelegateeDelegators(delegatee.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn write_delegatee_delegators(env: &Env, delegatee: &Address, delegators: &Vec<Address>) {
+    env.storage().persistent().set(
+        &DataKey::DelegateeDelegators(delegatee.clone()),
+        delegators,
+    );
+}
+
+pub fn append_delegatee_delegator(env: &Env, delegatee: &Address, delegator: &Address) {
+    let mut delegators = read_delegatee_delegators(env, delegatee);
+    let mut found = false;
+    for existing in delegators.iter() {
+        if existing == *delegator {
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        delegators.push_back(delegator.clone());
+        write_delegatee_delegators(env, delegatee, &delegators);
+    }
+}
+
+pub fn remove_delegatee_delegator(env: &Env, delegatee: &Address, delegator: &Address) {
+    let delegators = read_delegatee_delegators(env, delegatee);
+    let mut next = Vec::new(env);
+    for existing in delegators.iter() {
+        if existing != *delegator {
+            next.push_back(existing);
+        }
+    }
+    write_delegatee_delegators(env, delegatee, &next);
+}
+
+pub fn append_proposal_lifecycle_event(
+    env: &Env,
+    proposal_id: u64,
+    event: &ProposalLifecycleEvent,
+) -> u64 {
+    let sequence = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ProposalLifecycleCount(proposal_id))
+        .unwrap_or(0)
+        + 1;
+    env.storage()
+        .persistent()
+        .set(&DataKey::ProposalLifecycleCount(proposal_id), &sequence);
+    env.storage().persistent().set(
+        &DataKey::ProposalLifecycle(proposal_id, sequence),
+        event,
+    );
+    sequence
+}
+
+pub fn read_proposal_lifecycle_event(
+    env: &Env,
+    proposal_id: u64,
+    sequence: u64,
+) -> Option<ProposalLifecycleEvent> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ProposalLifecycle(proposal_id, sequence))
+}
+
+pub fn get_proposal_lifecycle_count(env: &Env, proposal_id: u64) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ProposalLifecycleCount(proposal_id))
+        .unwrap_or(0)
+}
+
+pub fn increment_referral_reward_counter(env: &Env) -> u64 {
+    let counter = env
+        .storage()
+        .instance()
+        .get(&DataKey::ReferralRewardCounter)
+        .unwrap_or(0)
+        + 1;
+    env.storage()
+        .instance()
+        .set(&DataKey::ReferralRewardCounter, &counter);
+    counter
+}
+
+pub fn write_referral_reward(env: &Env, entry: &ReferralRewardEntry) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::ReferralReward(entry.id), entry);
+}
+
+pub fn get_referral_reward_counter(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ReferralRewardCounter)
+        .unwrap_or(0)
+}
+
+pub fn read_referral_reward(env: &Env, reward_id: u64) -> Option<ReferralRewardEntry> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ReferralReward(reward_id))
 }
 
 pub fn get_pool_counter(env: &Env) -> u64 {

--- a/smartcontract/src/test.rs
+++ b/smartcontract/src/test.rs
@@ -1718,10 +1718,14 @@ fn test_governance_proposal_lifecycle() {
             token_symbol: String::from_str(&env, "CBG"),
             quorum_bps: 2_000,
             proposal_threshold: 100,
+            total_voting_supply: 10_000,
             voting_period_secs: 100,
             timelock_secs: 10,
         },
     );
+
+    client.set_voting_stake(&proposer, &500);
+    client.set_voting_stake(&voter, &2000);
 
     let mut actions = soroban_sdk::Vec::new(&env);
     actions.push_back(String::from_str(&env, "set_fee_rate:25"));
@@ -1730,15 +1734,17 @@ fn test_governance_proposal_lifecycle() {
         &String::from_str(&env, "Lower protocol fee"),
         &String::from_str(&env, "Reduce taker fees via governance"),
         &actions,
-        &500,
     );
 
-    client.cast_vote(&voter, &proposal_id, &VoteChoice::For, &500);
+    client.cast_vote(&voter, &proposal_id, &VoteChoice::For);
     env.ledger().set_timestamp(env.ledger().timestamp() + 120);
     client.execute_proposal(&proposal_id);
 
     let proposal = client.get_proposal(&proposal_id);
     assert_eq!(proposal.status, ProposalStatus::Executed);
+
+    let lifecycle = client.get_proposal_lifecycle(&proposal_id);
+    assert!(lifecycle.len() >= 2);
 }
 
 #[test]
@@ -1812,10 +1818,63 @@ fn test_advanced_order_amendment_and_referral_tracking() {
     assert_eq!(order.to_amount, 2_200);
 
     client.register_referral_code(&owner, &String::from_str(&env, "FROST"));
-    client.record_referral_swap(&String::from_str(&env, "FROST"), &77, &10_000);
+    let reward_id = client.record_referral_swap(&String::from_str(&env, "FROST"), &77, &10_000);
     let referral = client.get_referral_record(&String::from_str(&env, "FROST"));
     assert_eq!(referral.uses, 1);
     assert_eq!(referral.rewards_earned, 100);
+    assert_eq!(referral.rewards_pending, 100);
+
+    client.settle_referral_reward(&reward_id);
+    let settled = client.get_referral_record(&String::from_str(&env, "FROST"));
+    assert_eq!(settled.rewards_pending, 0);
+    assert_eq!(settled.rewards_settled, 100);
+
+    let claimed = client.claim_referral_rewards(&owner, &String::from_str(&env, "FROST"));
+    assert_eq!(claimed, 100);
+    let claimed_record = client.get_referral_record(&String::from_str(&env, "FROST"));
+    assert_eq!(claimed_record.rewards_settled, 0);
+    assert_eq!(claimed_record.rewards_claimed, 100);
+}
+
+#[test]
+fn test_governance_delegated_voting_power() {
+    let (env, _, client) = setup_contract();
+    let admin = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegatee = Address::generate(&env);
+
+    client.init(&admin);
+    client.init_governance(
+        &admin,
+        &GovernanceConfig {
+            token_symbol: String::from_str(&env, "CBG"),
+            quorum_bps: 1_000,
+            proposal_threshold: 100,
+            total_voting_supply: 10_000,
+            voting_period_secs: 100,
+            timelock_secs: 10,
+        },
+    );
+
+    client.set_voting_stake(&delegator, &300);
+    client.set_voting_stake(&delegatee, &200);
+    client.delegate_votes(&delegator, &delegatee);
+
+    let mut actions = soroban_sdk::Vec::new(&env);
+    actions.push_back(String::from_str(&env, "set_fee_rate:25"));
+    client.set_voting_stake(&delegatee, &200);
+    let proposal_id = client.create_proposal(
+        &delegatee,
+        &String::from_str(&env, "Delegated vote test"),
+        &String::from_str(&env, "Verify delegated voting power"),
+        &actions,
+    );
+
+    let effective = client.get_voting_power(&delegatee, &proposal_id);
+    assert_eq!(effective, 500);
+
+    let used = client.cast_vote(&delegatee, &proposal_id, &VoteChoice::For);
+    assert_eq!(used, 500);
 }
 
 // =============================================================================

--- a/smartcontract/src/types.rs
+++ b/smartcontract/src/types.rs
@@ -203,8 +203,26 @@ pub struct GovernanceConfig {
     pub token_symbol: String,
     pub quorum_bps: u32,
     pub proposal_threshold: i128,
+    pub total_voting_supply: i128,
     pub voting_period_secs: u64,
     pub timelock_secs: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OptProposalStatus {
+    None,
+    Status(ProposalStatus),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalLifecycleEvent {
+    pub sequence: u64,
+    pub from_status: OptProposalStatus,
+    pub to_status: ProposalStatus,
+    pub occurred_at: u64,
+    pub detail: String,
 }
 
 #[contracttype]
@@ -274,10 +292,44 @@ pub struct LiquidityPosition {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReferralRewardStatus {
+    Pending,
+    Settled,
+    Claimed,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReferralRewardEntry {
+    pub id: u64,
+    pub code: String,
+    pub swap_id: u64,
+    pub amount: i128,
+    pub status: ReferralRewardStatus,
+    pub created_at: u64,
+    pub settled_at: u64,
+    pub claimed_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReferralSharePayload {
+    pub code: String,
+    pub owner: Address,
+    pub qr_content: String,
+    pub share_url: String,
+    pub created_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReferralRecord {
     pub owner: Address,
     pub code: String,
     pub uses: u64,
     pub rewards_earned: i128,
+    pub rewards_pending: i128,
+    pub rewards_settled: i128,
+    pub rewards_claimed: i128,
     pub last_swap_id: u64,
 }

--- a/smartcontract/test_snapshots/test/test_advanced_order_amendment_and_referral_tracking.1.json
+++ b/smartcontract/test_snapshots/test/test_advanced_order_amendment_and_referral_tracking.1.json
@@ -202,6 +202,31 @@
       ]
     ],
     [],
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "claim_referral_rewards",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "string": "FROST"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     []
   ],
   "ledger": {
@@ -538,6 +563,17 @@
                     },
                     {
                       "key": {
+                        "symbol": "rewards_claimed"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 100
+                        }
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "rewards_earned"
                       },
                       "val": {
@@ -549,10 +585,149 @@
                     },
                     {
                       "key": {
+                        "symbol": "rewards_pending"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "rewards_settled"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "uses"
                       },
                       "val": {
                         "u64": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ReferralReward"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ReferralReward"
+                    },
+                    {
+                      "u64": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 100
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed_at"
+                      },
+                      "val": {
+                        "u64": 1000000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "code"
+                      },
+                      "val": {
+                        "string": "FROST"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": 1000000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "id"
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "settled_at"
+                      },
+                      "val": {
+                        "u64": 1000000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Claimed"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "swap_id"
+                      },
+                      "val": {
+                        "u64": 77
                       }
                     }
                   ]
@@ -604,6 +779,18 @@
                           "vec": [
                             {
                               "symbol": "OrderCounter"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ReferralRewardCounter"
                             }
                           ]
                         },
@@ -709,6 +896,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
                   }
                 },
                 "durability": "temporary",
@@ -1395,6 +1615,181 @@
                 "symbol": "record_referral_swap"
               }
             ],
+            "data": {
+              "u64": 1
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "get_referral_record"
+              }
+            ],
+            "data": {
+              "string": "FROST"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "get_referral_record"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "code"
+                  },
+                  "val": {
+                    "string": "FROST"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "last_swap_id"
+                  },
+                  "val": {
+                    "u64": 77
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "owner"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "rewards_claimed"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "rewards_earned"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 100
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "rewards_pending"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 100
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "rewards_settled"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "uses"
+                  },
+                  "val": {
+                    "u64": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "settle_referral_reward"
+              }
+            ],
+            "data": {
+              "u64": 1
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "settle_referral_reward"
+              }
+            ],
             "data": "void"
           }
         }
@@ -1470,12 +1865,230 @@
                 },
                 {
                   "key": {
+                    "symbol": "rewards_claimed"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "rewards_earned"
                   },
                   "val": {
                     "i128": {
                       "hi": 0,
                       "lo": 100
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "rewards_pending"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "rewards_settled"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 100
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "uses"
+                  },
+                  "val": {
+                    "u64": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "claim_referral_rewards"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "string": "FROST"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "claim_referral_rewards"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 100
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "get_referral_record"
+              }
+            ],
+            "data": {
+              "string": "FROST"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "get_referral_record"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "code"
+                  },
+                  "val": {
+                    "string": "FROST"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "last_swap_id"
+                  },
+                  "val": {
+                    "u64": 77
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "owner"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "rewards_claimed"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 100
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "rewards_earned"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 100
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "rewards_pending"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "rewards_settled"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
                     }
                   }
                 },

--- a/smartcontract/test_snapshots/test/test_governance_delegated_voting_power.1.json
+++ b/smartcontract/test_snapshots/test/test_governance_delegated_voting_power.1.json
@@ -35,7 +35,7 @@
                         "symbol": "quorum_bps"
                       },
                       "val": {
-                        "u32": 2000
+                        "u32": 1000
                       }
                     },
                     {
@@ -97,7 +97,7 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 500
+                    "lo": 300
                   }
                 }
               ]
@@ -122,7 +122,7 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 2000
+                    "lo": 200
                   }
                 }
               ]
@@ -139,16 +139,63 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "create_proposal",
+              "function_name": "delegate_votes",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "string": "Lower protocol fee"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_voting_stake",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "string": "Reduce taker fees via governance"
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_proposal",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "string": "Delegated vote test"
+                },
+                {
+                  "string": "Verify delegated voting power"
                 },
                 {
                   "vec": [
@@ -164,6 +211,7 @@
         }
       ]
     ],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
@@ -192,21 +240,137 @@
           "sub_invocations": []
         }
       ]
-    ],
-    [],
-    [],
-    []
+    ]
   ],
   "ledger": {
     "protocol_version": 21,
     "sequence_number": 0,
-    "timestamp": 1000120,
+    "timestamp": 1000000,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
     "min_temp_entry_ttl": 16,
     "max_entry_ttl": 6312000,
     "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "DelegateeDelegators"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "DelegateeDelegators"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Delegation"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Delegation"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "delegatee"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "delegator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "updated_at"
+                      },
+                      "val": {
+                        "u64": 1000000
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
       [
         {
           "contract_data": {
@@ -291,7 +455,7 @@
                         "symbol": "description"
                       },
                       "val": {
-                        "string": "Reduce taker fees via governance"
+                        "string": "Verify delegated voting power"
                       }
                     },
                     {
@@ -309,7 +473,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 2000
+                          "lo": 500
                         }
                       }
                     },
@@ -326,7 +490,7 @@
                         "symbol": "proposer"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -336,7 +500,7 @@
                       "val": {
                         "vec": [
                           {
-                            "symbol": "Executed"
+                            "symbol": "Active"
                           }
                         ]
                       }
@@ -346,7 +510,7 @@
                         "symbol": "title"
                       },
                       "val": {
-                        "string": "Lower protocol fee"
+                        "string": "Delegated vote test"
                       }
                     },
                     {
@@ -473,220 +637,6 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "ProposalLifecycle"
-                },
-                {
-                  "u64": 1
-                },
-                {
-                  "u64": 2
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "ProposalLifecycle"
-                    },
-                    {
-                      "u64": 1
-                    },
-                    {
-                      "u64": 2
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "detail"
-                      },
-                      "val": {
-                        "string": "voting_finalized"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "from_status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Status"
-                          },
-                          {
-                            "vec": [
-                              {
-                                "symbol": "Active"
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "occurred_at"
-                      },
-                      "val": {
-                        "u64": 1000120
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "sequence"
-                      },
-                      "val": {
-                        "u64": 2
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "to_status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Succeeded"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "ProposalLifecycle"
-                },
-                {
-                  "u64": 1
-                },
-                {
-                  "u64": 3
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "ProposalLifecycle"
-                    },
-                    {
-                      "u64": 1
-                    },
-                    {
-                      "u64": 3
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "detail"
-                      },
-                      "val": {
-                        "string": "proposal_executed"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "from_status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Status"
-                          },
-                          {
-                            "vec": [
-                              {
-                                "symbol": "Succeeded"
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "occurred_at"
-                      },
-                      "val": {
-                        "u64": 1000120
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "sequence"
-                      },
-                      "val": {
-                        "u64": 3
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "to_status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Executed"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
                   "symbol": "ProposalLifecycleCount"
                 },
                 {
@@ -716,7 +666,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "u64": 3
+                  "u64": 1
                 }
               }
             },
@@ -814,7 +764,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 500
+                    "lo": 300
                   }
                 }
               }
@@ -862,7 +812,7 @@
                 "val": {
                   "i128": {
                     "hi": 0,
-                    "lo": 2000
+                    "lo": 200
                   }
                 }
               }
@@ -933,7 +883,7 @@
                                 "symbol": "quorum_bps"
                               },
                               "val": {
-                                "u32": 2000
+                                "u32": 1000
                               }
                             },
                             {
@@ -1163,6 +1113,72 @@
       ],
       [
         {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 8370022561469687789
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 8370022561469687789
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
           "contract_code": {
             "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           }
@@ -1273,7 +1289,7 @@
                         "symbol": "quorum_bps"
                       },
                       "val": {
-                        "u32": 2000
+                        "u32": 1000
                       }
                     },
                     {
@@ -1367,7 +1383,7 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 500
+                    "lo": 300
                   }
                 }
               ]
@@ -1424,7 +1440,118 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 2000
+                    "lo": 200
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "set_voting_stake"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "delegate_votes"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "delegate_votes"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "set_voting_stake"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
                   }
                 }
               ]
@@ -1476,13 +1603,13 @@
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "string": "Lower protocol fee"
+                  "string": "Delegated vote test"
                 },
                 {
-                  "string": "Reduce taker fees via governance"
+                  "string": "Verify delegated voting power"
                 },
                 {
                   "vec": [
@@ -1515,6 +1642,65 @@
             ],
             "data": {
               "u64": 1
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "get_voting_power"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "get_voting_power"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 500
+              }
             }
           }
         }
@@ -1579,438 +1765,8 @@
             "data": {
               "i128": {
                 "hi": 0,
-                "lo": 2000
+                "lo": 500
               }
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": null,
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_call"
-              },
-              {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
-              },
-              {
-                "symbol": "execute_proposal"
-              }
-            ],
-            "data": {
-              "u64": 1
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "execute_proposal"
-              }
-            ],
-            "data": "void"
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": null,
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_call"
-              },
-              {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
-              },
-              {
-                "symbol": "get_proposal"
-              }
-            ],
-            "data": {
-              "u64": 1
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "get_proposal"
-              }
-            ],
-            "data": {
-              "map": [
-                {
-                  "key": {
-                    "symbol": "abstain_votes"
-                  },
-                  "val": {
-                    "i128": {
-                      "hi": 0,
-                      "lo": 0
-                    }
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "actions"
-                  },
-                  "val": {
-                    "vec": [
-                      {
-                        "string": "set_fee_rate:25"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "against_votes"
-                  },
-                  "val": {
-                    "i128": {
-                      "hi": 0,
-                      "lo": 0
-                    }
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "created_at"
-                  },
-                  "val": {
-                    "u64": 1000000
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "description"
-                  },
-                  "val": {
-                    "string": "Reduce taker fees via governance"
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "executable_after"
-                  },
-                  "val": {
-                    "u64": 1000110
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "for_votes"
-                  },
-                  "val": {
-                    "i128": {
-                      "hi": 0,
-                      "lo": 2000
-                    }
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "id"
-                  },
-                  "val": {
-                    "u64": 1
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "proposer"
-                  },
-                  "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "status"
-                  },
-                  "val": {
-                    "vec": [
-                      {
-                        "symbol": "Executed"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "title"
-                  },
-                  "val": {
-                    "string": "Lower protocol fee"
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "voting_ends_at"
-                  },
-                  "val": {
-                    "u64": 1000100
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": null,
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_call"
-              },
-              {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
-              },
-              {
-                "symbol": "get_proposal_lifecycle"
-              }
-            ],
-            "data": {
-              "u64": 1
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "get_proposal_lifecycle"
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "detail"
-                      },
-                      "val": {
-                        "string": "proposal_created"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "from_status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "occurred_at"
-                      },
-                      "val": {
-                        "u64": 1000000
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "sequence"
-                      },
-                      "val": {
-                        "u64": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "to_status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "detail"
-                      },
-                      "val": {
-                        "string": "voting_finalized"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "from_status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Status"
-                          },
-                          {
-                            "vec": [
-                              {
-                                "symbol": "Active"
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "occurred_at"
-                      },
-                      "val": {
-                        "u64": 1000120
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "sequence"
-                      },
-                      "val": {
-                        "u64": 2
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "to_status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Succeeded"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "detail"
-                      },
-                      "val": {
-                        "string": "proposal_executed"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "from_status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Status"
-                          },
-                          {
-                            "vec": [
-                              {
-                                "symbol": "Succeeded"
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "occurred_at"
-                      },
-                      "val": {
-                        "u64": 1000120
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "sequence"
-                      },
-                      "val": {
-                        "u64": 3
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "to_status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Executed"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-              ]
             }
           }
         }


### PR DESCRIPTION
closes #501 
closes #503 
closes #509 
closes #510 


## Summary

This PR implements four related protocol workspace contributions in a single branch:

1. **Governance voting power** — deterministic delegation and quorum math aligned with DAO rules
2. **Proposal lifecycle history** — persisted status transitions exposed via API and rendered in `/protocol`
3. **QR-friendly referral payloads** — mobile-scannable share content with a fallback web link
4. **Referral reward settlement** — end-to-end tracking of pending, settled, and claimed rewards

## Changes

### Smart contract (`smartcontract/`)

- Added on-chain voting stake storage and `get_voting_power` resolution
- Combined self-voted and delegated power without double counting
- Rejected self-delegation; only the latest delegation record is honored
- Fixed quorum calculation to use `total_voting_supply * quorum_bps / 10_000`
- Removed caller-supplied `voting_power` from `create_proposal` and `cast_vote`
- Persisted proposal lifecycle events on create, finalize, and execute
- Extended referral records with `rewards_pending`, `rewards_settled`, and `rewards_claimed`
- Added referral reward settlement and claim flows
- Added tests for governance lifecycle, delegated voting power, and referral settlement

### Backend (`backend/`)

- Added protocol models: `GovernanceProposal`, `ReferralCampaign`, `ReferralReward`
- Added Alembic migration `20260530_0004_add_protocol_tables`
- Added `/api/v1/protocol` routes for:
  - Governance proposals and lifecycle transitions
  - Voting power breakdown
  - Referral campaigns, share payloads, reward settlement, and claims
- Added referral share payload generation with:
  - `qr_content` deep link
  - `share_url` fallback link
  - `qr_image_base64` PNG for clients that render QR directly
- Added service-layer tests for voting power and referral payload generation

### Frontend (`frontend/`)

- Added protocol API client at `frontend/src/lib/api/protocol.ts`
- Updated `/protocol` to load governance and referral data from the API
- Rendered proposal lifecycle timeline using `ActivityTimeline`
- Displayed referral QR image, fallback share link, and pending/settled/claimed balances

### Docs

- Updated `docs/ROADMAP_FOUNDATIONS.md` with voting power rules and edge cases:
  - self-delegation
  - double counting
  - stale delegation records

## Acceptance criteria

### Voting power
- [x] Define how delegated and self-voted power are combined
- [x] Enforce proposal thresholds with deterministic calculations
- [x] Document edge cases for self-delegation, double counting, and stale delegation records

### Proposal lifecycle
- [x] Persist proposal status transitions or equivalent lifecycle events
- [x] Expose the history through an API response
- [x] Render the timeline in the protocol workspace

### QR referral payloads
- [x] Generate QR payload content from referral metadata
- [x] Keep the payload compatible with mobile scanning flows
- [x] Provide a fallback text link for clients without QR support

### Referral settlement
- [x] Record pending, settled, and claimed referral rewards
- [x] Expose settlement status in API responses
- [x] Keep balances consistent after payout execution

## Test plan

- [ ] Run smart contract tests:
  ```bash
  cd smartcontract
  cargo test governance referral