### PR TITLE
[Frontend UX] Reorder sidebar navigation around primary workflows

### DIFF
--- a/frontend/src/components/layout/MobileNavDrawer.tsx
+++ b/frontend/src/components/layout/MobileNavDrawer.tsx
@@ -6,7 +6,7 @@ import { Drawer } from "@/components/ui/drawer";
 import { DarkModeToggle } from "./DarkModeToggle";
 import { WalletConnect } from "@/components/swap/WalletConnect";
 import { CommandPalette } from "./CommandPalette";
-import { NAV_LINKS } from "./navigation";
+import { PRIMARY_NAV_LINKS, SECONDARY_NAV_LINKS } from "./navigation";
 import { useI18n } from "@/components/i18n/I18nProvider";
 import { useSettingsStore } from "@/hooks/useSettings";
 import { useIsAdmin } from "@/hooks/useIsAdmin";
@@ -96,8 +96,44 @@ export function MobileNavDrawer({ open, onClose }: MobileNavDrawerProps) {
       aria-label="Mobile navigation"
     >
       <nav aria-label="Mobile navigation links">
+        {/* Primary workflow actions */}
         <ul className="space-y-1" role="list">
-          {NAV_LINKS.filter((link) => link.href !== "/admin" || isAdmin).map((link) => {
+          {PRIMARY_NAV_LINKS.map((link) => {
+            const active = normalizedPathname === link.href;
+            return (
+              <li key={link.href}>
+                <Link
+                  href={localizePath(link.href)}
+                  onClick={onClose}
+                  aria-current={active ? "page" : undefined}
+                  className={cn(
+                    "flex items-center rounded-xl px-4 py-3 text-base font-medium transition-all",
+                    active
+                      ? "bg-brand-500/10 text-brand-500"
+                      : "text-text-secondary hover:bg-surface-overlay hover:text-text-primary active:bg-surface-overlay"
+                  )}
+                >
+                  {t(link.key)}
+                  {active && (
+                    <div
+                      className="ml-auto h-1.5 w-1.5 rounded-full bg-brand-500"
+                      aria-hidden="true"
+                    />
+                  )}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+
+        {/* Divider between primary and secondary */}
+        <div className="my-3 px-2">
+          <div className="h-px bg-border" role="separator" aria-hidden="true" />
+        </div>
+
+        {/* Secondary / admin / info routes */}
+        <ul className="space-y-1" role="list">
+          {SECONDARY_NAV_LINKS.filter((link) => link.href !== "/admin" || isAdmin).map((link) => {
             const active = normalizedPathname === link.href;
             return (
               <li key={link.href}>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { useI18n } from "@/components/i18n/I18nProvider";
-import { NAV_LINKS } from "./navigation";
+import { PRIMARY_NAV_LINKS, SECONDARY_NAV_LINKS } from "./navigation";
 import { Layers, ChevronRight } from "lucide-react";
 import { stripLocaleFromPathname } from "@/lib/i18n/config";
 import { shouldPrefetch } from "@/lib/prefetch";
@@ -33,8 +33,9 @@ export function Sidebar() {
 
       {/* Sidebar Navigation */}
       <nav className="flex-1 overflow-y-auto py-6 px-3 no-scrollbar" aria-label="Main Navigation">
+        {/* Primary workflow actions */}
         <ul className="space-y-1.5" role="list">
-          {NAV_LINKS.filter((link) => link.href !== "/admin" || isAdmin).map((link) => {
+          {PRIMARY_NAV_LINKS.map((link) => {
             const isActive = normalizedPathname === link.href;
             return (
               <li key={link.href}>
@@ -50,7 +51,51 @@ export function Sidebar() {
                   )}
                 >
                   <div className="flex items-center gap-3">
-                    {/* Visual indicator for active state */}
+                    <div
+                      className={cn(
+                        "h-1.5 w-1.5 rounded-full transition-all duration-300",
+                        isActive
+                          ? "bg-brand-500 scale-100"
+                          : "bg-transparent scale-0 group-hover:bg-text-muted/30 group-hover:scale-100"
+                      )}
+                    />
+                    {t(link.key)}
+                  </div>
+                  {isActive && (
+                    <ChevronRight
+                      size={14}
+                      className="animate-in slide-in-from-left-1 duration-300"
+                    />
+                  )}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+
+        {/* Divider between primary and secondary */}
+        <div className="my-4 px-2">
+          <div className="h-px bg-border" role="separator" aria-hidden="true" />
+        </div>
+
+        {/* Secondary / admin / info routes */}
+        <ul className="space-y-1.5" role="list">
+          {SECONDARY_NAV_LINKS.filter((link) => link.href !== "/admin" || isAdmin).map((link) => {
+            const isActive = normalizedPathname === link.href;
+            return (
+              <li key={link.href}>
+                <Link
+                  href={localizePath(link.href)}
+                  prefetch={shouldPrefetch(link.href, normalizedPathname)}
+                  aria-current={isActive ? "page" : undefined}
+                  className={cn(
+                    "group flex items-center justify-between rounded-xl px-4 py-2.5 text-sm font-medium transition-all duration-200",
+                    isActive
+                      ? "bg-brand-500/10 text-brand-500 shadow-sm"
+                      : "text-text-secondary hover:bg-surface-overlay hover:text-text-primary"
+                  )}
+                >
+                  <div className="flex items-center gap-3">
                     <div
                       className={cn(
                         "h-1.5 w-1.5 rounded-full transition-all duration-300",

--- a/frontend/src/components/layout/navigation.ts
+++ b/frontend/src/components/layout/navigation.ts
@@ -1,12 +1,18 @@
-export const NAV_LINKS = [
+export const PRIMARY_NAV_LINKS = [
   { key: "nav.dashboard", href: "/dashboard" },
   { key: "nav.swap", href: "/swap" },
   { key: "nav.market", href: "/marketplace" },
   { key: "nav.orders", href: "/orders" },
-  { key: "nav.htlcs", href: "/htlcs" },
-  { key: "nav.settings", href: "/settings" },
-  { key: "nav.protocol", href: "/protocol" },
   { key: "nav.explorer", href: "/transactions" },
+] as const;
+
+export const SECONDARY_NAV_LINKS = [
+  { key: "nav.htlcs", href: "/htlcs" },
+  { key: "nav.protocol", href: "/protocol" },
+  { key: "nav.settings", href: "/settings" },
   { key: "nav.about", href: "/about" },
   { key: "nav.admin", href: "/admin" },
 ] as const;
+
+// Flat list for consumers that don't need grouping (admin filter still applies)
+export const NAV_LINKS = [...PRIMARY_NAV_LINKS, ...SECONDARY_NAV_LINKS] as const;


### PR DESCRIPTION
## Summary

- Reorders `NAV_LINKS` to place primary workflow actions first: **Dashboard → Swap → Marketplace → Orders → Explorer (Activity)**
- Adds a horizontal divider between primary and secondary groups in both desktop Sidebar and mobile Drawer
- Secondary/admin/info routes follow the divider: **HTLCs → Protocol → Settings → About → Admin**
- Exports `PRIMARY_NAV_LINKS` and `SECONDARY_NAV_LINKS` from `navigation.ts` for grouped render; flat `NAV_LINKS` kept for other consumers
- Mobile drawer mirrors the exact same order and grouping as the desktop sidebar

## Test plan

- [ ] Desktop sidebar shows Dashboard, Swap, Market, Orders, Explorer at the top, then a divider, then HTLCs, Protocol, Settings, About (Admin only for admins)
- [ ] Mobile drawer reflects the same order and grouping
- [ ] Active-state indicator and `aria-current="page"` still work on all links in both groups
- [ ] Admin link still hidden for non-admin users

Closes #407
Closes #408
Closes #409
Closes #417