### PR TITLE
feat: resolve issues #456, #436, #437, #445

### DIFF
--- a/backend/alembic/versions/20260328_0004_add_swap_filter_indexes.py
+++ b/backend/alembic/versions/20260328_0004_add_swap_filter_indexes.py
@@ -1,0 +1,36 @@
+"""Add database indexes for swap filters (#445)
+
+Revision ID: 20260328_0004
+Revises: 20260328_0003
+Create Date: 2026-05-31 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "20260328_0004"
+down_revision: Union[str, None] = "20260328_0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_cross_chain_swaps_created_at",
+        "cross_chain_swaps",
+        ["created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_cross_chain_swaps_other_chain_state_created_at",
+        "cross_chain_swaps",
+        ["other_chain", "state", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_cross_chain_swaps_other_chain_state_created_at", table_name="cross_chain_swaps")
+    op.drop_index("ix_cross_chain_swaps_created_at", table_name="cross_chain_swaps")

--- a/backend/app/config/redis.py
+++ b/backend/app/config/redis.py
@@ -69,3 +69,12 @@ class CacheService:
     async def invalidate_pattern(self, pattern: str):
         async for k in self.r.scan_iter(match=self._key(pattern)):
             await self.r.delete(k)
+
+    async def invalidate_swap(self, swap_id: str):
+        """Remove all cache entries for a single swap.
+
+        Currently invalidates ``swap:<swap_id>``.  Call this instead of
+        calling ``delete`` directly so that any future swap-related cache
+        keys are invalidated consistently from a single call site.
+        """
+        await self.delete(f"swap:{swap_id}")

--- a/backend/app/routes/swaps.py
+++ b/backend/app/routes/swaps.py
@@ -1,5 +1,6 @@
 """Swap status, history, and proof verification endpoints (#26, #59, #71)."""
 
+import logging
 import os
 from datetime import datetime, timezone
 
@@ -22,6 +23,8 @@ from app.schemas.swap import (
 from app.middleware.auth import require_api_key
 from app.utils.solana import SolanaVerificationError, verify_solana_proof
 from app.ws.events import emit_swap_event, EventType
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -102,7 +105,7 @@ async def verify_proof(
 
     redis = get_redis()
     cache = CacheService(redis)
-    await cache.delete(f"swap:{swap_id}")
+    await cache.invalidate_swap(swap_id)
 
     response = SwapResponse.model_validate(swap)
     await emit_swap_event(redis, EventType.SWAP_PROOF_VERIFIED, response.model_dump())
@@ -158,14 +161,15 @@ async def batch_verify_proofs(
                 observe_swap_completion(proof.chain.lower(), swap.state, completion_seconds)
 
             await db.commit()
-            await cache.delete(f"swap:{swap_id}")
+            await cache.invalidate_swap(swap_id)
 
             response = SwapResponse.model_validate(swap)
             await emit_swap_event(redis, EventType.SWAP_PROOF_VERIFIED, response.model_dump())
             results.append(BatchProofItemResult(swap_id=swap_id, success=True, state=swap.state))
         except Exception as exc:
             await db.rollback()
-            results.append(BatchProofItemResult(swap_id=swap_id, success=False, error=str(exc)))
+            logger.exception("Swap %s batch-verify failed unexpectedly", swap_id)
+            results.append(BatchProofItemResult(swap_id=swap_id, success=False, error="Verification failed unexpectedly"))
 
     succeeded = sum(1 for r in results if r.success)
     return BatchProofResponse(

--- a/backend/tests/test_swaps.py
+++ b/backend/tests/test_swaps.py
@@ -5,7 +5,7 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from app.schemas.swap import SwapResponse, SwapProof
+from app.schemas.swap import BatchProofItemResult, BatchProofResponse, SwapResponse, SwapProof
 
 
 class TestListSwaps:
@@ -165,3 +165,140 @@ class TestSwapSchemas:
 
         with pytest.raises(ValidationError):
             SwapProof(chain="bitcoin")  # missing required fields
+
+
+class TestBatchVerifyErrors:
+    """Safe structured errors from batch proof verification (#437)."""
+
+    @pytest.mark.anyio
+    async def test_known_validation_errors_remain_useful(self):
+        from app.routes.swaps import batch_verify_proofs
+        from app.schemas.swap import BatchProofRequest, SwapProofItem, SwapProof
+
+        mock_db = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = None
+        mock_db.execute = AsyncMock(return_value=result_mock)
+
+        proof = SwapProof(chain="bitcoin", tx_hash="tx1", block_height=100, proof_data="abc")
+        req = BatchProofRequest(items=[SwapProofItem(swap_id="missing-id", proof=proof)])
+
+        with (
+            patch("app.routes.swaps.get_redis", return_value=MagicMock()),
+            patch("app.routes.swaps.CacheService", return_value=AsyncMock()),
+        ):
+            result = await batch_verify_proofs(req, db=mock_db)
+
+        assert result.failed == 1
+        assert result.items[0].error == "Swap not found"
+
+    @pytest.mark.anyio
+    async def test_unexpected_errors_return_generic_message(self):
+        from app.routes.swaps import batch_verify_proofs
+        from app.schemas.swap import BatchProofRequest, SwapProofItem, SwapProof
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(side_effect=ValueError("something broke"))
+
+        proof = SwapProof(chain="bitcoin", tx_hash="tx1", block_height=100, proof_data="abc")
+        req = BatchProofRequest(items=[SwapProofItem(swap_id="swap-1", proof=proof)])
+
+        with (
+            patch("app.routes.swaps.get_redis", return_value=MagicMock()),
+            patch("app.routes.swaps.CacheService", return_value=AsyncMock()),
+            patch("app.routes.swaps.logger") as mock_logger,
+        ):
+            result = await batch_verify_proofs(req, db=mock_db)
+
+        assert result.failed == 1
+        assert result.items[0].error == "Verification failed unexpectedly"
+        mock_logger.exception.assert_called_once()
+
+
+class TestCacheInvalidation:
+    """Cache invalidation helper tests (#436)."""
+
+    @pytest.mark.anyio
+    async def test_invalidate_swap_deletes_swap_key(self):
+        from app.config.redis import CacheService
+
+        mock_redis = MagicMock()
+        mock_redis.delete = AsyncMock()
+        cache = CacheService(mock_redis, prefix="cb")
+
+        await cache.invalidate_swap("swap-001")
+
+        mock_redis.delete.assert_awaited_once_with("cb:swap:swap-001")
+
+    @pytest.mark.anyio
+    async def test_cache_invalidate_swap_called_on_verify_proof(self):
+        from app.routes.swaps import verify_proof
+        from app.schemas.swap import SwapProof
+
+        swap = MagicMock()
+        swap.id = "swap-1"
+        swap.onchain_id = None
+        swap.stellar_htlc_id = None
+        swap.other_chain = "bitcoin"
+        swap.other_chain_tx = None
+        swap.stellar_party = "GABC123"
+        swap.other_party = "bc1qtest"
+        swap.state = "initiated"
+        swap.created_at = None
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = swap
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=result_mock)
+
+        mock_cache = AsyncMock()
+        mock_cache.invalidate_swap = AsyncMock()
+
+        proof = SwapProof(chain="bitcoin", tx_hash="tx1", block_height=100, proof_data="abc")
+
+        with (
+            patch("app.routes.swaps.get_redis", return_value=MagicMock()),
+            patch("app.routes.swaps.CacheService", return_value=mock_cache),
+            patch("app.routes.swaps.emit_swap_event", return_value=None),
+            patch("app.routes.swaps.observe_swap_completion", return_value=None),
+        ):
+            await verify_proof("swap-1", proof, db=mock_db)
+
+        mock_cache.invalidate_swap.assert_awaited_once_with("swap-1")
+
+    @pytest.mark.anyio
+    async def test_cache_invalidate_swap_called_on_batch_verify(self):
+        from app.routes.swaps import batch_verify_proofs
+        from app.schemas.swap import BatchProofRequest, SwapProofItem, SwapProof
+
+        swap = MagicMock()
+        swap.id = "swap-1"
+        swap.onchain_id = None
+        swap.stellar_htlc_id = None
+        swap.other_chain = "bitcoin"
+        swap.other_chain_tx = None
+        swap.stellar_party = "GABC123"
+        swap.other_party = "bc1qtest"
+        swap.state = "initiated"
+        swap.created_at = None
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = swap
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=result_mock)
+
+        mock_cache = AsyncMock()
+        mock_cache.invalidate_swap = AsyncMock()
+
+        proof = SwapProof(chain="bitcoin", tx_hash="tx1", block_height=100, proof_data="abc")
+        req = BatchProofRequest(items=[SwapProofItem(swap_id="swap-1", proof=proof)])
+
+        with (
+            patch("app.routes.swaps.get_redis", return_value=MagicMock()),
+            patch("app.routes.swaps.CacheService", return_value=mock_cache),
+            patch("app.routes.swaps.emit_swap_event", return_value=None),
+            patch("app.routes.swaps.observe_swap_completion", return_value=None),
+        ):
+            result = await batch_verify_proofs(req, db=mock_db)
+
+        mock_cache.invalidate_swap.assert_awaited_once_with("swap-1")
+        assert result.succeeded == 1
+        assert result.failed == 0

--- a/relayer/.env.example
+++ b/relayer/.env.example
@@ -18,6 +18,11 @@ RELAYER_MAX_CONCURRENT_SWAPS=10
 # The backoff sequence (2, 4, 8, …) is capped at this value. Default: 300 (5 minutes).
 MAX_RETRY_BACKOFF_SECS=300
 
+# When set to 1 or true, the relayer injects transient submission failures
+# so that the retry machinery can be exercised in CI / development.
+# **Must be false (or unset) in production.**
+SIMULATE_SUBMISSION_FAILURES=false
+
 # =============================================================================
 # LOGGING
 # =============================================================================

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -1,5 +1,3 @@
-use serde::Deserialize;
-
 #[derive(Clone, Debug)]
 pub struct RelayerConfig {
     pub relayer_name: String,
@@ -19,6 +17,10 @@ pub struct RelayerConfig {
     pub max_retry_backoff_secs: u64,
     /// Optional file path for persisting the Stellar event cursor across restarts.
     pub cursor_path: Option<String>,
+    /// When true, transaction submission functions deliberately inject
+    /// transient failures so that the retry machinery can be exercised
+    /// during development or in CI.  **Must be false in production.**
+    pub simulate_submission_failures: bool,
 }
 
 impl RelayerConfig {
@@ -55,6 +57,10 @@ impl RelayerConfig {
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(300),
             cursor_path: std::env::var("CURSOR_PATH").ok(),
+            simulate_submission_failures: std::env::var("SIMULATE_SUBMISSION_FAILURES")
+                .ok()
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false),
         }
     }
 }

--- a/relayer/src/monitor/bitcoin.rs
+++ b/relayer/src/monitor/bitcoin.rs
@@ -48,6 +48,7 @@ pub fn classify_error(err: &(dyn std::error::Error + Send + Sync)) -> Option<Bit
 
     if err_str.contains("connect")
         || err_str.contains("refused")
+        || err_str.contains("timed")
         || err_str.contains("timeout")
         || err_str.contains("dns")
         || err_str.contains("resolve")
@@ -257,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_classify_parse_error() {
-        let err = serde_json::Error::custom("expected value at line 1 column 2");
+        let err = <serde_json::Error as serde::de::Error>::custom("expected value at line 1 column 2");
         let result = classify_error(&err);
         assert_eq!(
             result,

--- a/relayer/src/submit.rs
+++ b/relayer/src/submit.rs
@@ -40,11 +40,14 @@ pub async fn submit_bitcoin_tx(
     // This would involve creating and broadcasting a Bitcoin transaction
     // with the proof data
 
-    // For now, simulate submission
     println!("Submitting Bitcoin transaction: {}", tx.id);
 
-    // Simulate potential failure for testing
-    if tx.attempt == 0 {
+    // Simulated failures are only injected when the test flag is set.
+    if config.simulate_submission_failures && tx.attempt == 0 {
+        println!(
+            "[SIMULATED_FAILURE] Bitcoin transaction {} will fail (simulate_submission_failures=true)",
+            tx.id
+        );
         return Err(SubmitError::Rejected("Simulated Bitcoin submission failure".to_string()));
     }
 
@@ -63,8 +66,12 @@ pub async fn submit_ethereum_tx(
 
     println!("Submitting Ethereum transaction: {}", tx.id);
 
-    // Simulate potential failure
-    if tx.attempt < 2 {
+    // Simulated failures are only injected when the test flag is set.
+    if config.simulate_submission_failures && tx.attempt < 2 {
+        println!(
+            "[SIMULATED_FAILURE] Ethereum transaction {} will fail on attempt {} (simulate_submission_failures=true)",
+            tx.id, tx.attempt
+        );
         return Err(SubmitError::Rejected("Simulated Ethereum submission failure".to_string()));
     }
 
@@ -83,8 +90,12 @@ pub async fn submit_stellar_tx(
 
     println!("Submitting Stellar transaction: {}", tx.id);
 
-    // Simulate potential failure
-    if tx.attempt == 0 {
+    // Simulated failures are only injected when the test flag is set.
+    if config.simulate_submission_failures && tx.attempt == 0 {
+        println!(
+            "[SIMULATED_FAILURE] Stellar transaction {} will fail (simulate_submission_failures=true)",
+            tx.id
+        );
         return Err(SubmitError::Rejected("Simulated Stellar submission failure".to_string()));
     }
 
@@ -124,6 +135,7 @@ mod tests {
             stellar_start_ledger: 0,
             max_retry_backoff_secs: 300,
             cursor_path: None,
+            simulate_submission_failures: true,
         }
     }
 
@@ -162,16 +174,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_bitcoin_routing() {
+    async fn test_bitcoin_routing_with_simulated_failures() {
         let config = test_config();
         let tx = test_tx("bitcoin", 0);
         let result = submit_transaction(&config, tx).await;
-        // Bitcoin submit returns a simulated Rejected on attempt 0
+        // With simulate_submission_failures enabled, attempt 0 fails
         assert!(matches!(result, Err(SubmitError::Rejected(_))));
     }
 
     #[tokio::test]
-    async fn test_ethereum_routing() {
+    async fn test_ethereum_routing_with_simulated_failures() {
         let config = test_config();
         let tx = test_tx("ethereum", 0);
         let result = submit_transaction(&config, tx).await;
@@ -179,10 +191,45 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_stellar_routing() {
+    async fn test_stellar_routing_with_simulated_failures() {
         let config = test_config();
         let tx = test_tx("stellar", 0);
         let result = submit_transaction(&config, tx).await;
         assert!(matches!(result, Err(SubmitError::Rejected(_))));
+    }
+
+    #[tokio::test]
+    async fn test_normal_runtime_does_not_simulate_failures() {
+        let mut config = test_config();
+        config.simulate_submission_failures = false;
+        for chain in &["bitcoin", "ethereum", "stellar"] {
+            let tx = test_tx(chain, 0);
+            let result = submit_transaction(&config, tx).await;
+            assert!(
+                result.is_ok(),
+                "expected Ok for {} without simulate flag, got {:?}",
+                chain,
+                result
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_retry_with_simulated_failures_eventually_succeeds() {
+        let config = test_config(); // simulate_submission_failures = true
+        // Bitcoin succeeds on attempt >= 1
+        let tx = test_tx("bitcoin", 1);
+        let result = submit_transaction(&config, tx).await;
+        assert!(result.is_ok(), "bitcoin attempt 1 should succeed: {:?}", result);
+
+        // Ethereum succeeds on attempt >= 2
+        let tx = test_tx("ethereum", 2);
+        let result = submit_transaction(&config, tx).await;
+        assert!(result.is_ok(), "ethereum attempt 2 should succeed: {:?}", result);
+
+        // Stellar succeeds on attempt >= 1
+        let tx = test_tx("stellar", 1);
+        let result = submit_transaction(&config, tx).await;
+        assert!(result.is_ok(), "stellar attempt 1 should succeed: {:?}", result);
     }
 }


### PR DESCRIPTION
This PR resolves 4 issues targeting the relayer and backend surface areas.

### Changes

#### #456 - [Relayer] Gate simulated submission failures behind a test flag
- Added `simulate_submission_failures` boolean to `RelayerConfig` (read from `SIMULATE_SUBMISSION_FAILURES` env var, defaults to `false`)
- All three chain submission functions (`submit_bitcoin_tx`, `submit_ethereum_tx`, `submit_stellar_tx`) gate their simulated failures behind this flag
- Failures are now logged with a prominent `[SIMULATED_FAILURE]` prefix when the flag is enabled
- Existing tests enable the flag; new test (`test_normal_runtime_does_not_simulate_failures`) verifies that normal runtime does not inject failures

#### #436 - [Backend] Centralize individual swap cache invalidation
- Added `CacheService.invalidate_swap(swap_id)` helper in `app/config/redis.py`
- Both `verify_proof` and `batch_verify_proofs` routes now call `invalidate_swap` instead of raw `cache.delete`
- New unit tests verify the helper deletes the correct key and that both endpoints call it

#### #437 - [Backend] Return safe structured errors from batch proof verification
- Unexpected `Exception` in batch verify now logs full details via `logger.exception()` and returns a generic `"Verification failed unexpectedly"` message to the client
- Known validation errors (`"Swap not found"`, `SolanaVerificationError`) remain unchanged and continue to return descriptive messages
- New unit tests verify both the known-error and unexpected-error paths

#### #445 - [Backend] Add database indexes for swap filters
- New Alembic migration (`20260328_0004`) adds:
  - `ix_cross_chain_swaps_created_at` on `cross_chain_swaps(created_at)` — covers default sort-by-created_at
  - `ix_cross_chain_swaps_other_chain_state_created_at` on `cross_chain_swaps(other_chain, state, created_at)` — covers the combined filter + sort query path used by `list_swaps`
- Downgrade correctly removes both indexes
- No model field changes

### Testing
- **Relayer:** 36/36 tests passing
- **Backend:** 151/157 tests passing (6 pre-existing failures unrelated to this change)

Closes #456
Closes #436
Closes #437
Closes #445