### PR TITLE
fix: config validation, graceful shutdown, conflict response, rate-limit tests

### DIFF
--- a/backend/app/routes/assets.py
+++ b/backend/app/routes/assets.py
@@ -71,7 +71,7 @@ async def create_asset(
         )
     )
     if existing.scalar_one_or_none():
-        raise HTTPException(status_code=400, detail="Asset already exists")
+        raise HTTPException(status_code=409, detail="conflict")
 
     new_asset = Asset(**asset.model_dump())
     db.add(new_asset)

--- a/backend/tests/test_assets.py
+++ b/backend/tests/test_assets.py
@@ -1,0 +1,109 @@
+"""Tests for asset endpoints."""
+
+from uuid import uuid4
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from sqlalchemy import select
+
+from app.models.asset import Asset
+from app.schemas.asset import AssetResponse, AssetCreate
+
+
+def make_asset(**overrides):
+    values = {
+        "id": uuid4(),
+        "chain": "stellar",
+        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+        "symbol": "USDC",
+        "name": "USD Coin",
+        "decimals": 6,
+        "description": "Stablecoin from Circle",
+        "icon_url": None,
+        "website_url": None,
+        "is_verified": True,
+        "is_active": True,
+        "tags": None,
+    }
+    values.update(overrides)
+    asset = Asset()
+    for key, value in values.items():
+        setattr(asset, key, value)
+    return asset
+
+
+class TestAssetSchemas:
+    def test_asset_response_from_dict(self):
+        data = {
+            "id": "asset-001",
+            "chain": "stellar",
+            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+            "symbol": "USDC",
+            "name": "USD Coin",
+            "decimals": 6,
+            "is_verified": True,
+            "is_active": True,
+        }
+        resp = AssetResponse(**data)
+        assert resp.id == "asset-001"
+        assert resp.chain == "stellar"
+        assert resp.symbol == "USDC"
+
+
+class TestAssetEndpoints:
+    @pytest.mark.anyio
+    async def test_create_asset_success(self, client, mock_db):
+        with patch("app.routes.assets.get_db", return_value=mock_db):
+            with patch("app.routes.assets.require_api_key", return_value=None):
+                mock_db.execute = AsyncMock()
+                mock_db.execute.return_value.scalar_one_or_none = MagicMock(return_value=None)
+                mock_db.commit = AsyncMock()
+                mock_db.refresh = AsyncMock()
+
+                response = await client.post(
+                    "/assets/",
+                    json={
+                        "chain": "stellar",
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+                        "symbol": "USDC",
+                        "name": "USD Coin",
+                        "decimals": 6,
+                    },
+                    headers={"X-API-Key": "test-key"},
+                )
+                assert response.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_create_asset_duplicate_returns_conflict(self, client, mock_db):
+        with patch("app.routes.assets.get_db", return_value=mock_db):
+            with patch("app.routes.assets.require_api_key", return_value=None):
+                existing_asset = make_asset(
+                    chain="stellar",
+                    address="CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+                    symbol="USDC",
+                )
+                mock_db.execute = AsyncMock()
+                mock_db.execute.return_value.scalar_one_or_none = MagicMock(return_value=existing_asset)
+
+                response = await client.post(
+                    "/assets/",
+                    json={
+                        "chain": "stellar",
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+                        "symbol": "USDC",
+                        "name": "USD Coin",
+                        "decimals": 6,
+                    },
+                    headers={"X-API-Key": "test-key"},
+                )
+                assert response.status_code == 409
+                assert response.json()["detail"] == "conflict"
+
+    @pytest.mark.anyio
+    async def test_list_assets_unchanged(self, client, mock_db):
+        with patch("app.routes.assets.get_db", return_value=mock_db):
+            mock_db.execute = AsyncMock()
+            mock_db.execute.return_value.scalars.return_value.all = MagicMock(return_value=[])
+
+            response = await client.get("/assets/")
+            assert response.status_code == 200
+            assert response.json() == []

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,112 @@
+"""Tests for rate limiting middleware."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi import Request, Response
+from starlette.responses import JSONResponse
+
+
+@pytest.mark.anyio
+async def test_rate_limit_disabled():
+    with patch("app.middleware.rate_limit.settings") as mock_settings:
+        mock_settings.rate_limit_enabled = False
+
+        from app.middleware.rate_limit import RateLimitMiddleware
+
+        middleware = RateLimitMiddleware(app=None)
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.client.host = "127.0.0.1"
+        mock_request.headers.get = MagicMock(return_value="")
+
+        next_handler = AsyncMock(return_value=Response(status_code=200))
+
+        result = await middleware.dispatch(mock_request, next_handler)
+
+        assert result.status_code == 200
+        next_handler.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_rate_limit_enabled_enforces_limit():
+    with patch("app.middleware.rate_limit.settings") as mock_settings:
+        mock_settings.rate_limit_enabled = True
+        mock_settings.rate_limit_requests = 2
+        mock_settings.rate_limit_window_seconds = 60
+
+        with patch("app.middleware.rate_limit.redis_pool") as mock_redis:
+            from app.middleware.rate_limit import RateLimitMiddleware
+
+            middleware = RateLimitMiddleware(app=None)
+
+            mock_request = MagicMock(spec=Request)
+            mock_request.client.host = "127.0.0.1"
+            mock_request.headers.get = MagicMock(return_value="")
+
+            mock_response = Response(status_code=200)
+            mock_response.headers = {}
+            next_handler = AsyncMock(return_value=mock_response)
+
+            mock_redis.incr = AsyncMock(return_value=3)
+            mock_redis.expire = AsyncMock()
+            mock_redis.ttl = AsyncMock(return_value=45)
+
+            result = await middleware.dispatch(mock_request, next_handler)
+
+            assert result.status_code == 429
+            assert result.headers.get("Retry-After") == "45"
+
+
+@pytest.mark.anyio
+async def test_rate_limit_enabled_allows_under_limit():
+    with patch("app.middleware.rate_limit.settings") as mock_settings:
+        mock_settings.rate_limit_enabled = True
+        mock_settings.rate_limit_requests = 10
+        mock_settings.rate_limit_window_seconds = 60
+
+        with patch("app.middleware.rate_limit.redis_pool") as mock_redis:
+            from app.middleware.rate_limit import RateLimitMiddleware
+
+            middleware = RateLimitMiddleware(app=None)
+
+            mock_request = MagicMock(spec=Request)
+            mock_request.client.host = "127.0.0.1"
+            mock_request.headers.get = MagicMock(return_value="")
+
+            mock_response = Response(status_code=200)
+            mock_response.headers = {}
+            next_handler = AsyncMock(return_value=mock_response)
+
+            mock_redis.incr = AsyncMock(return_value=5)
+            mock_redis.expire = AsyncMock()
+            mock_redis.ttl = AsyncMock(return_value=50)
+
+            result = await middleware.dispatch(mock_request, next_handler)
+
+            assert result.status_code == 200
+            assert result.headers.get("X-RateLimit-Limit") == "10"
+            assert result.headers.get("X-RateLimit-Remaining") == "5"
+
+
+@pytest.mark.anyio
+async def test_rate_limit_no_redis_allows_requests():
+    with patch("app.middleware.rate_limit.settings") as mock_settings:
+        mock_settings.rate_limit_enabled = True
+        mock_settings.rate_limit_requests = 10
+        mock_settings.rate_limit_window_seconds = 60
+
+        with patch("app.middleware.rate_limit.redis_pool", None):
+            from app.middleware.rate_limit import RateLimitMiddleware
+
+            middleware = RateLimitMiddleware(app=None)
+
+            mock_request = MagicMock(spec=Request)
+            mock_request.client.host = "127.0.0.1"
+            mock_request.headers.get = MagicMock(return_value="")
+
+            mock_response = Response(status_code=200)
+            next_handler = AsyncMock(return_value=mock_response)
+
+            result = await middleware.dispatch(mock_request, next_handler)
+
+            assert result.status_code == 200

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -25,7 +25,7 @@ pub struct RelayerConfig {
 
 impl RelayerConfig {
     pub fn from_env() -> Self {
-        Self {
+        let config = Self {
             relayer_name: std::env::var("RELAYER_NAME").unwrap_or_else(|_| "default".into()),
             relayer_fee_bps: std::env::var("RELAYER_FEE_BPS")
                 .ok()
@@ -61,6 +61,20 @@ impl RelayerConfig {
                 .ok()
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false),
+        };
+        config.validate();
+        config
+    }
+
+    fn validate(&self) {
+        if self.contract_id.is_empty() {
+            eprintln!("Error: CHAINBRIDGE_CONTRACT_ID is required but not set. Set the environment variable and try again.");
+            std::process::exit(1);
+        }
+
+        if let Err(e) = self.metrics_bind_addr.parse::<std::net::SocketAddr>() {
+            eprintln!("Error: RELAYER_METRICS_BIND '{}' is not a valid socket address: {}. Set a valid address like '0.0.0.0:9108'.", self.metrics_bind_addr, e);
+            std::process::exit(1);
         }
     }
 }

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -4,6 +4,7 @@
 //! generates cross-chain proofs, and submits them to complete atomic swaps.
 
 use std::net::SocketAddr;
+use tokio::sync::broadcast;
 
 mod config;
 mod metrics;
@@ -20,16 +21,15 @@ async fn main() {
     let config = config::RelayerConfig::from_env();
     let metrics = metrics::RelayerMetrics::new(env!("CARGO_PKG_VERSION"));
 
-    let metrics_addr: SocketAddr = config
-        .metrics_bind_addr
-        .parse()
-        .unwrap_or_else(|_| "0.0.0.0:9108".parse().expect("valid metrics bind address"));
+    let metrics_addr: SocketAddr = config.metrics_bind_addr.parse().expect("config already validated");
 
     let metrics_handle = tokio::spawn(metrics::serve(metrics.clone(), metrics_addr));
     println!("Relayer metrics available on http://{}/metrics", metrics_addr);
 
     let retry_processor = retry::RetryProcessor::new(config.clone(), metrics.clone());
     let retry_queue = retry_processor.queue().clone();
+
+    let (shutdown_tx, _) = broadcast::channel(1);
 
     // Spawn chain monitoring tasks
     let stellar_handle = tokio::spawn(monitor::stellar::monitor_loop(
@@ -55,12 +55,28 @@ async fn main() {
 
     println!("Relayer running. Press Ctrl+C to stop.");
 
-    // Wait for any monitor to exit (they shouldn't under normal operation)
+    let shutdown_signal = async {
+        tokio::signal::ctrl_c().await.ok();
+    };
+
     tokio::select! {
+        _ = shutdown_signal => {
+            println!("Shutdown signal received (Ctrl+C)");
+            let _ = shutdown_tx.send(());
+            abort_tasks(&[&metrics_handle, &stellar_handle, &bitcoin_handle, &ethereum_handle, &retry_handle]).await;
+            println!("Relayer shutdown complete");
+        }
         r = metrics_handle => eprintln!("Metrics server exited: {:?}", r),
         r = stellar_handle => eprintln!("Stellar monitor exited: {:?}", r),
         r = bitcoin_handle => eprintln!("Bitcoin monitor exited: {:?}", r),
         r = ethereum_handle => eprintln!("Ethereum monitor exited: {:?}", r),
         r = retry_handle => eprintln!("Retry processor exited: {:?}", r),
     }
+}
+
+async fn abort_tasks(handles: &[&tokio::task::JoinHandle<()>]) {
+    for handle in handles {
+        handle.abort();
+    }
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 }


### PR DESCRIPTION
## What
Adds configuration validation at startup, implements graceful Ctrl+C shutdown, returns 409 for duplicate asset-chain pairs, and adds comprehensive rate-limit tests.

## Issues Resolved
Closes #448
Closes #449
Closes #447
Closes #446

## Changes

### #448 - Validate required config before starting monitors
Added validation in RelayerConfig::validate() to check CHAINBRIDGE_CONTRACT_ID is set and RELAYER_METRICS_BIND is a valid socket address. Startup fails with clear error messages if validation fails.

### #449 - Add graceful shutdown on Ctrl+C
Implemented tokio signal handling to listen for SIGINT (Ctrl+C), gracefully abort all monitor and metrics tasks, and log shutdown status.

### #447 - Add conflict response for duplicate asset-chain records
Changed asset creation endpoint to return HTTP 409 (Conflict) instead of 400 (Bad Request) when a duplicate asset-chain pair is inserted. Added test covering the duplicate path.

### #446 - Add tests for rate-limit disabled mode
Added comprehensive tests for rate limiting: disabled mode allows all requests, enabled mode enforces limit, and no-Redis fallback works correctly.