### PR TITLE
feat(orders): add amendment history visibility (#512)

### DIFF
--- a/backend/alembic/versions/20260601_0005_add_order_amendment_columns.py
+++ b/backend/alembic/versions/20260601_0005_add_order_amendment_columns.py
@@ -1,0 +1,38 @@
+"""Add amendment_count and amendment_log to swap_orders."""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260601_0005"
+down_revision: Union[str, None] = "20260530_0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "swap_orders",
+        sa.Column(
+            "amendment_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "swap_orders",
+        sa.Column(
+            "amendment_log",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("swap_orders", "amendment_log")
+    op.drop_column("swap_orders", "amendment_count")

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -1,6 +1,6 @@
 import uuid
 from sqlalchemy import Column, String, BigInteger, Integer, ForeignKey
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 from .base import Base, TimestampMixin
 
 
@@ -27,3 +27,5 @@ class SwapOrder(Base, TimestampMixin):
     expiry = Column(BigInteger, nullable=False, index=True)
     status = Column(String, nullable=False, default="open", index=True)
     counterparty = Column(String, nullable=True)
+    amendment_count = Column(Integer, nullable=False, default=0)
+    amendment_log = Column(JSONB, nullable=False, default=list)

--- a/backend/app/routes/orders.py
+++ b/backend/app/routes/orders.py
@@ -1,5 +1,6 @@
-"""Order book endpoints: create, list, match, cancel (#26, #59)."""
+"""Order book endpoints: create, list, match, cancel, amend (#26, #59, #512)."""
 
+from datetime import datetime, timezone
 from typing import Annotated, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
@@ -8,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config.database import get_db
 from app.config.redis import get_redis, CacheService
 from app.models.order import SwapOrder
-from app.schemas.order import OrderCreate, OrderResponse, OrderMatch
+from app.schemas.order import OrderAmend, OrderCreate, OrderResponse, OrderMatch
 from app.middleware.auth import require_api_key
 from app.services.order_matching import OrderMatchingService
 from app.ws.events import emit_order_event, EventType
@@ -145,6 +146,63 @@ async def match_order(
 
     response = OrderResponse.model_validate(order)
     await emit_order_event(redis, EventType.ORDER_MATCHED, response.model_dump())
+    return response
+
+
+@router.patch("/{order_id}/amend", response_model=OrderResponse)
+async def amend_order(
+    order_id: str,
+    data: OrderAmend,
+    db: AsyncSession = Depends(get_db),
+    _=Depends(require_api_key),
+):
+    result = await db.execute(select(SwapOrder).where(SwapOrder.id == order_id))
+    order = result.scalar_one_or_none()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    if order.status != "open":
+        raise HTTPException(status_code=400, detail="Only open orders can be amended")
+
+    changes: dict = {}
+    if data.from_amount is not None and data.from_amount != order.from_amount:
+        changes["from_amount"] = {"before": int(order.from_amount), "after": data.from_amount}
+        order.from_amount = data.from_amount
+    if data.to_amount is not None and data.to_amount != order.to_amount:
+        changes["to_amount"] = {"before": int(order.to_amount), "after": data.to_amount}
+        order.to_amount = data.to_amount
+    if data.min_fill_amount is not None and data.min_fill_amount != order.min_fill_amount:
+        changes["min_fill_amount"] = {
+            "before": int(order.min_fill_amount) if order.min_fill_amount is not None else None,
+            "after": data.min_fill_amount,
+        }
+        order.min_fill_amount = data.min_fill_amount
+    if data.expiry is not None and data.expiry != order.expiry:
+        changes["expiry"] = {"before": int(order.expiry), "after": data.expiry}
+        order.expiry = data.expiry
+
+    if not changes:
+        raise HTTPException(status_code=400, detail="No fields changed")
+
+    entry = {
+        "sequence": int(order.amendment_count or 0) + 1,
+        "amended_at": datetime.now(timezone.utc).isoformat(),
+        "changes": changes,
+    }
+    if data.note:
+        entry["note"] = data.note
+
+    order.amendment_count = int(order.amendment_count or 0) + 1
+    order.amendment_log = list(order.amendment_log or []) + [entry]
+
+    await db.commit()
+    await db.refresh(order)
+
+    redis = get_redis()
+    cache = CacheService(redis)
+    await cache.invalidate_pattern("orders:*")
+
+    response = OrderResponse.model_validate(order)
+    await emit_order_event(redis, EventType.ORDER_UPDATED, response.model_dump())
     return response
 
 

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, field_validator, model_validator
-from typing import Optional
+from typing import Any, Optional
 from datetime import datetime
 
 from app.utils.address_validation import (
@@ -40,6 +40,30 @@ class OrderCreate(BaseModel):
         return self
 
 
+class OrderAmend(BaseModel):
+    from_amount: Optional[int] = Field(default=None, gt=0)
+    to_amount: Optional[int] = Field(default=None, gt=0)
+    min_fill_amount: Optional[int] = Field(default=None, gt=0)
+    expiry: Optional[int] = Field(default=None, gt=0)
+    note: Optional[str] = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self):
+        if all(
+            v is None
+            for v in (self.from_amount, self.to_amount, self.min_fill_amount, self.expiry)
+        ):
+            raise ValueError("At least one amendable field must be provided")
+        return self
+
+
+class OrderAmendmentEntry(BaseModel):
+    sequence: int
+    amended_at: str
+    changes: dict[str, Any]
+    note: Optional[str] = None
+
+
 class OrderMatch(BaseModel):
     counterparty: str
     fill_amount: Optional[int] = None
@@ -69,6 +93,8 @@ class OrderResponse(BaseModel):
     status: str
     counterparty: Optional[str] = None
     created_at: Optional[datetime] = None
+    amendment_count: int = 0
+    amendment_log: list[dict[str, Any]] = []
 
     class Config:
         from_attributes = True

--- a/backend/app/ws/events.py
+++ b/backend/app/ws/events.py
@@ -46,6 +46,7 @@ class EventType(str, Enum):
     ORDER_MATCHED = "order.matched"
     ORDER_CANCELLED = "order.cancelled"
     ORDER_FILLED = "order.filled"
+    ORDER_UPDATED = "order.updated"
 
 
 def _build_event(event_type: EventType, channel: str, data: Any) -> str:

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -7,7 +7,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from app.models.order import SwapOrder
-from app.schemas.order import OrderResponse
+from app.schemas.order import OrderAmend, OrderResponse
 from app.services.order_matching import OrderMatchingService
 
 
@@ -28,6 +28,8 @@ def make_order(**overrides):
         "status": "open",
         "counterparty": None,
         "created_at": now,
+        "amendment_count": 0,
+        "amendment_log": [],
     }
     values.update(overrides)
     order = SwapOrder()
@@ -54,6 +56,104 @@ class TestOrderSchemas:
         resp = OrderResponse(**data)
         assert resp.id == "order-001"
         assert resp.status == "open"
+        assert resp.amendment_count == 0
+        assert resp.amendment_log == []
+
+    def test_order_response_includes_amendment_fields(self):
+        log_entry = {
+            "sequence": 1,
+            "amended_at": "2026-06-01T10:00:00+00:00",
+            "changes": {"from_amount": {"before": 50, "after": 100}},
+        }
+        data = {
+            "id": "order-002",
+            "creator": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "from_chain": "stellar",
+            "to_chain": "ethereum",
+            "from_asset": "XLM",
+            "to_asset": "USDC",
+            "from_amount": 100,
+            "to_amount": 200,
+            "filled_amount": 0,
+            "expiry": 9999999999,
+            "status": "open",
+            "amendment_count": 1,
+            "amendment_log": [log_entry],
+        }
+        resp = OrderResponse(**data)
+        assert resp.amendment_count == 1
+        assert len(resp.amendment_log) == 1
+        assert resp.amendment_log[0]["sequence"] == 1
+
+
+class TestOrderAmendSchema:
+    def test_valid_amend_single_field(self):
+        data = OrderAmend(from_amount=500)
+        assert data.from_amount == 500
+        assert data.to_amount is None
+
+    def test_valid_amend_multiple_fields(self):
+        data = OrderAmend(from_amount=300, to_amount=600, note="repriced")
+        assert data.from_amount == 300
+        assert data.to_amount == 600
+        assert data.note == "repriced"
+
+    def test_rejects_zero_fields_changed(self):
+        with pytest.raises(ValueError, match="At least one amendable field must be provided"):
+            OrderAmend()
+
+    def test_rejects_zero_amounts(self):
+        with pytest.raises(ValueError):
+            OrderAmend(from_amount=0)
+
+    def test_expiry_amend(self):
+        data = OrderAmend(expiry=9999999999)
+        assert data.expiry == 9999999999
+
+
+class TestAmendOrderLogic:
+    def test_amendment_increments_count(self):
+        order = make_order()
+        assert order.amendment_count == 0
+
+        order.from_amount = 150
+        order.amendment_count = order.amendment_count + 1
+        entry = {
+            "sequence": 1,
+            "amended_at": datetime.now(timezone.utc).isoformat(),
+            "changes": {"from_amount": {"before": 100, "after": 150}},
+        }
+        order.amendment_log = list(order.amendment_log) + [entry]
+
+        assert order.amendment_count == 1
+        assert len(order.amendment_log) == 1
+        assert order.amendment_log[0]["sequence"] == 1
+
+    def test_multiple_amendments_append_in_order(self):
+        order = make_order()
+        now = datetime.now(timezone.utc)
+
+        for i in range(1, 4):
+            order.amendment_count = i
+            entry = {
+                "sequence": i,
+                "amended_at": now.isoformat(),
+                "changes": {"from_amount": {"before": i * 10, "after": (i + 1) * 10}},
+            }
+            order.amendment_log = list(order.amendment_log) + [entry]
+
+        assert order.amendment_count == 3
+        assert [e["sequence"] for e in order.amendment_log] == [1, 2, 3]
+
+    def test_no_changes_does_not_amend(self):
+        order = make_order(from_amount=100)
+        amend = OrderAmend(from_amount=100, to_amount=200)
+        changes = {}
+        if amend.from_amount is not None and amend.from_amount != order.from_amount:
+            changes["from_amount"] = {"before": order.from_amount, "after": amend.from_amount}
+        if amend.to_amount is not None and amend.to_amount != order.to_amount:
+            changes["to_amount"] = {"before": order.to_amount, "after": amend.to_amount}
+        assert changes == {}
 
 
 class TestOrderMatchingService:

--- a/frontend/src/app/(orders)/orders/page.tsx
+++ b/frontend/src/app/(orders)/orders/page.tsx
@@ -5,8 +5,11 @@ import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   BookmarkPlus,
+  ChevronDown,
+  ChevronUp,
   Clock3,
   Filter,
+  History,
   LayoutGrid,
   Rows3,
   RefreshCw,
@@ -20,7 +23,7 @@ import {
 import { Button, Card, EmptyState, Input, Spinner, ToastContainer } from "@/components/ui";
 import { WalletConnect } from "@/components/swap/WalletConnect";
 import { DEMO_ORDER_OWNER, useMockOrders, useOrderBookStore } from "@/hooks/useOrderBook";
-import { Order, OrderStatus } from "@/types";
+import { Order, OrderAmendmentEntry, OrderStatus } from "@/types";
 import { cn } from "@/lib/utils";
 import { shortenHash } from "@/lib/format";
 import { AdvancedFilterDrawer } from "@/components/filters/AdvancedFilterDrawer";
@@ -99,6 +102,7 @@ export default function OrdersPage() {
   const [pendingCancelId, setPendingCancelId] = useState<string | null>(null);
   const [orderToCancel, setOrderToCancel] = useState<Order | null>(null);
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const [expandedAmendmentId, setExpandedAmendmentId] = useState<string | null>(null);
 
   useEffect(() => {
     seedMockOrders(ownerAddress);
@@ -459,89 +463,134 @@ export default function OrdersPage() {
             }
           />
         ) : (
-          visibleOrders.map((order) => (
-            <Card
-              key={order.id}
-              variant="glass"
-              className={cn(orderCardPaddingClass)}
-            >
-              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                <div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-xl font-bold text-text-primary">{order.pair}</span>
-                    <span
-                      className={cn(
-                        "rounded-full px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.18em]",
-                        order.derivedStatus === OrderStatus.OPEN &&
-                          "bg-emerald-500/10 text-emerald-400",
-                        order.derivedStatus === OrderStatus.EXPIRED &&
-                          "bg-amber-500/10 text-amber-400",
-                        order.derivedStatus === OrderStatus.CANCELLED &&
-                          "bg-red-500/10 text-red-300",
-                        order.derivedStatus === OrderStatus.FILLED &&
-                          "bg-brand-500/10 text-brand-400"
-                      )}
-                    >
-                      {order.derivedStatus}
-                    </span>
-                    {pendingCancelId === order.id && (
-                      <div className="flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-400">
-                        <Spinner size="sm" />
-                        <span>Cancelling</span>
-                      </div>
-                    )}
-                  </div>
-                  <div className="mt-3 grid gap-2 text-sm text-text-secondary sm:grid-cols-2">
-                    <p>Maker: {shortAddress(order.maker)}</p>
-                    <p>
-                      Chain Route: {order.chainIn} to {order.chainOut}
-                    </p>
-                    <p>
-                      Size: {order.amount} {order.tokenIn}
-                    </p>
-                    <p>
-                      Total: {order.total} {order.tokenOut}
-                    </p>
-                    <p>
-                      Expires:{" "}
-                      {order.expiresAt ? new Date(order.expiresAt).toLocaleString() : "Not set"}
-                    </p>
-                    <p>Created: {new Date(order.timestamp).toLocaleString()}</p>
-                  </div>
-                </div>
-
-                <div className="min-w-[220px] space-y-3">
-                  <div className="rounded-2xl border border-border bg-surface-raised p-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
-                      Order Summary
-                    </p>
-                    <p className="mt-3 text-sm text-text-secondary">
-                      Type: <span className="text-text-primary">{order.orderType ?? "limit"}</span>
-                    </p>
-                    <p className="mt-2 text-sm text-text-secondary">
-                      Partial fills:{" "}
-                      <span className="text-text-primary">
-                        {order.allowPartialFills ? "Enabled" : "Disabled"}
+          visibleOrders.map((order) => {
+            const isAmendmentExpanded = expandedAmendmentId === order.id;
+            const hasAmendments = (order.amendmentCount ?? 0) > 0;
+            return (
+              <Card
+                key={order.id}
+                variant="glass"
+                className={cn(orderCardPaddingClass)}
+              >
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-xl font-bold text-text-primary">{order.pair}</span>
+                      <span
+                        className={cn(
+                          "rounded-full px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.18em]",
+                          order.derivedStatus === OrderStatus.OPEN &&
+                            "bg-emerald-500/10 text-emerald-400",
+                          order.derivedStatus === OrderStatus.EXPIRED &&
+                            "bg-amber-500/10 text-amber-400",
+                          order.derivedStatus === OrderStatus.CANCELLED &&
+                            "bg-red-500/10 text-red-300",
+                          order.derivedStatus === OrderStatus.FILLED &&
+                            "bg-brand-500/10 text-brand-400"
+                        )}
+                      >
+                        {order.derivedStatus}
                       </span>
-                    </p>
+                      {hasAmendments && (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-brand-500/10 px-2.5 py-1 text-xs font-semibold text-brand-400">
+                          <History className="h-3 w-3" />
+                          {order.amendmentCount} {order.amendmentCount === 1 ? "amendment" : "amendments"}
+                        </span>
+                      )}
+                      {pendingCancelId === order.id && (
+                        <div className="flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-400">
+                          <Spinner size="sm" />
+                          <span>Cancelling</span>
+                        </div>
+                      )}
+                    </div>
+                    <div className="mt-3 grid gap-2 text-sm text-text-secondary sm:grid-cols-2">
+                      <p>Maker: {shortAddress(order.maker)}</p>
+                      <p>
+                        Chain Route: {order.chainIn} to {order.chainOut}
+                      </p>
+                      <p>
+                        Size: {order.amount} {order.tokenIn}
+                      </p>
+                      <p>
+                        Total: {order.total} {order.tokenOut}
+                      </p>
+                      <p>
+                        Expires:{" "}
+                        {order.expiresAt ? new Date(order.expiresAt).toLocaleString() : "Not set"}
+                      </p>
+                      <p>Created: {new Date(order.timestamp).toLocaleString()}</p>
+                    </div>
                   </div>
 
-                  <Button
-                    variant="destructive"
-                    className="w-full"
-                    icon={<XCircle className="h-4 w-4" />}
-                    loading={pendingCancelId === order.id}
-                    disabled={order.derivedStatus !== OrderStatus.OPEN}
-                    onClick={() => requestCancel(order)}
-                    aria-haspopup="dialog"
-                    aria-label={`Cancel order ${order.pair} (${order.id})`}
-                  >
-                    Cancel Order
-                  </Button>
+                  <div className="min-w-[220px] space-y-3">
+                    <div className="rounded-2xl border border-border bg-surface-raised p-4">
+                      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
+                        Order Summary
+                      </p>
+                      <p className="mt-3 text-sm text-text-secondary">
+                        Type: <span className="text-text-primary">{order.orderType ?? "limit"}</span>
+                      </p>
+                      <p className="mt-2 text-sm text-text-secondary">
+                        Partial fills:{" "}
+                        <span className="text-text-primary">
+                          {order.allowPartialFills ? "Enabled" : "Disabled"}
+                        </span>
+                      </p>
+                      {hasAmendments && (
+                        <p className="mt-2 text-sm text-text-secondary">
+                          Last amended:{" "}
+                          <span className="text-text-primary">
+                            {new Date(
+                              order.amendmentLog![order.amendmentLog!.length - 1].amended_at
+                            ).toLocaleString()}
+                          </span>
+                        </p>
+                      )}
+                    </div>
+
+                    {hasAmendments && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setExpandedAmendmentId(isAmendmentExpanded ? null : order.id)
+                        }
+                        className="flex w-full items-center justify-between rounded-xl border border-border bg-surface-raised px-3 py-2 text-xs font-medium text-text-secondary hover:bg-surface-overlay hover:text-text-primary"
+                        aria-expanded={isAmendmentExpanded}
+                      >
+                        <span className="flex items-center gap-1.5">
+                          <History className="h-3.5 w-3.5" />
+                          Amendment History
+                        </span>
+                        {isAmendmentExpanded ? (
+                          <ChevronUp className="h-3.5 w-3.5" />
+                        ) : (
+                          <ChevronDown className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                    )}
+
+                    <Button
+                      variant="destructive"
+                      className="w-full"
+                      icon={<XCircle className="h-4 w-4" />}
+                      loading={pendingCancelId === order.id}
+                      disabled={order.derivedStatus !== OrderStatus.OPEN}
+                      onClick={() => requestCancel(order)}
+                      aria-haspopup="dialog"
+                      aria-label={`Cancel order ${order.pair} (${order.id})`}
+                    >
+                      Cancel Order
+                    </Button>
+                  </div>
                 </div>
-              </div>
-            </Card>
-          ))
+
+                {isAmendmentExpanded && order.amendmentLog && order.amendmentLog.length > 0 && (
+                  <AmendmentHistory entries={order.amendmentLog} />
+                )}
+              </Card>
+            );
+          })
         )}
       </div>
 
@@ -712,6 +761,76 @@ export default function OrdersPage() {
           </div>
         </div>
       </AdvancedFilterDrawer>
+    </div>
+  );
+}
+
+const FIELD_LABELS: Record<string, string> = {
+  from_amount: "Send amount",
+  to_amount: "Receive amount",
+  min_fill_amount: "Min fill",
+  expiry: "Expiry",
+};
+
+function AmendmentHistory({ entries }: { entries: OrderAmendmentEntry[] }) {
+  const sorted = [...entries].sort((a, b) => b.sequence - a.sequence);
+  return (
+    <div className="mt-4 rounded-2xl border border-border bg-surface-overlay/30 p-4">
+      <p className="mb-3 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">
+        <History className="h-3.5 w-3.5" />
+        Amendment History
+      </p>
+      <ol className="space-y-3">
+        {sorted.map((entry, index) => (
+          <li key={entry.sequence} className="flex gap-3 text-sm">
+            <div className="flex flex-col items-center">
+              <span
+                className={cn(
+                  "flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold",
+                  index === 0
+                    ? "bg-brand-500/20 text-brand-400"
+                    : "bg-surface-raised text-text-muted"
+                )}
+              >
+                {entry.sequence}
+              </span>
+              {index < sorted.length - 1 && (
+                <div className="mt-1 w-px flex-1 bg-border" />
+              )}
+            </div>
+            <div className="pb-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-xs text-text-muted">
+                  {new Date(entry.amended_at).toLocaleString()}
+                </span>
+                {index === 0 && (
+                  <span className="rounded-full bg-brand-500/10 px-2 py-0.5 text-xs font-semibold text-brand-400">
+                    Latest
+                  </span>
+                )}
+              </div>
+              <ul className="mt-1.5 space-y-1">
+                {Object.entries(entry.changes).map(([field, change]) => (
+                  <li key={field} className="text-xs text-text-secondary">
+                    <span className="font-medium text-text-primary">
+                      {FIELD_LABELS[field] ?? field}
+                    </span>
+                    {": "}
+                    <span className="line-through text-text-muted">
+                      {change.before ?? "—"}
+                    </span>{" "}
+                    →{" "}
+                    <span className="font-medium text-text-primary">{change.after}</span>
+                  </li>
+                ))}
+              </ul>
+              {entry.note && (
+                <p className="mt-1 text-xs italic text-text-muted">&ldquo;{entry.note}&rdquo;</p>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
     </div>
   );
 }

--- a/frontend/src/hooks/useOrderBook.ts
+++ b/frontend/src/hooks/useOrderBook.ts
@@ -1,6 +1,13 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { AdvancedOrderType, Order, OrderBookStore, OrderSide, OrderStatus } from "@/types";
+import {
+  AdvancedOrderType,
+  Order,
+  OrderAmendmentEntry,
+  OrderBookStore,
+  OrderSide,
+  OrderStatus,
+} from "@/types";
 import { useCallback } from "react";
 
 export const DEMO_ORDER_OWNER = "cb-local-trader";
@@ -62,6 +69,16 @@ export const useMockOrders = () => {
           orderType: AdvancedOrderType.LIMIT,
           allowPartialFills: true,
           amendmentCount: 1,
+          amendmentLog: [
+            {
+              sequence: 1,
+              amended_at: new Date(Date.now() - 1000 * 60 * 20).toISOString(),
+              changes: {
+                from_amount: { before: 8000, after: 10000 },
+              },
+              note: "Increased order size",
+            },
+          ] as OrderAmendmentEntry[],
           minFillAmount: "2,500",
           takerFeeEstimate: "~0.0004 ETH",
         },
@@ -103,6 +120,24 @@ export const useMockOrders = () => {
           orderType: AdvancedOrderType.TWAP,
           allowPartialFills: true,
           amendmentCount: 2,
+          amendmentLog: [
+            {
+              sequence: 1,
+              amended_at: new Date(Date.now() - 1000 * 60 * 25).toISOString(),
+              changes: {
+                to_amount: { before: 400000, after: 450000 },
+              },
+            },
+            {
+              sequence: 2,
+              amended_at: new Date(Date.now() - 1000 * 60 * 10).toISOString(),
+              changes: {
+                min_fill_amount: { before: null, after: 1000 },
+                expiry: { before: 1800000, after: 2400000 },
+              },
+              note: "Set min fill and extended expiry",
+            },
+          ] as OrderAmendmentEntry[],
           minFillAmount: "0.01",
           takerFeeEstimate: "~35 XLM",
         },
@@ -144,6 +179,16 @@ export const useMockOrders = () => {
           orderType: AdvancedOrderType.LIMIT,
           allowPartialFills: true,
           amendmentCount: 1,
+          amendmentLog: [
+            {
+              sequence: 1,
+              amended_at: new Date(Date.now() - 1000 * 60 * 7).toISOString(),
+              changes: {
+                to_amount: { before: 170000, after: 184000 },
+              },
+              note: "Adjusted rate",
+            },
+          ] as OrderAmendmentEntry[],
           minFillAmount: "1,000",
           makerFeeEstimate: "~3 XLM",
         },
@@ -165,6 +210,24 @@ export const useMockOrders = () => {
           orderType: AdvancedOrderType.STOP_LOSS,
           allowPartialFills: false,
           amendmentCount: 3,
+          amendmentLog: [
+            {
+              sequence: 1,
+              amended_at: new Date(Date.now() - 1000 * 60 * 80).toISOString(),
+              changes: { from_amount: { before: 1000, after: 2000 } },
+            },
+            {
+              sequence: 2,
+              amended_at: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
+              changes: { to_amount: { before: 400000, after: 468000 } },
+              note: "Updated target price",
+            },
+            {
+              sequence: 3,
+              amended_at: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+              changes: { expiry: { before: 3600, after: 5400 } },
+            },
+          ] as OrderAmendmentEntry[],
           makerFeeEstimate: "~0.00003 BTC",
         },
       ];

--- a/frontend/src/lib/api/orders.ts
+++ b/frontend/src/lib/api/orders.ts
@@ -1,6 +1,7 @@
 import { createApiClient, getUserApiHeaders } from "@/lib/api/client";
 import { ApiOrderRecordSchema, ApiOrderListSchema } from "@/lib/api/schemas";
 import type {
+  AmendOrderPayload,
   ApiOrderRecord,
   CreateOrderPayload,
   ListOrdersParams,
@@ -37,6 +38,15 @@ export function cancelOrder(orderId: string) {
   return ordersClient.post<ApiOrderRecord>(
     `/${orderId}/cancel`,
     undefined,
+    undefined,
+    ApiOrderRecordSchema
+  );
+}
+
+export function amendOrder(orderId: string, payload: AmendOrderPayload) {
+  return ordersClient.patch<ApiOrderRecord>(
+    `/${orderId}/amend`,
+    payload,
     undefined,
     ApiOrderRecordSchema
   );

--- a/frontend/src/lib/api/schemas.ts
+++ b/frontend/src/lib/api/schemas.ts
@@ -6,6 +6,18 @@ import { z } from "zod";
 
 // ── Order Schemas ──────────────────────────────────────────────────────────────
 
+export const ApiOrderAmendmentChangeSchema = z.object({
+  before: z.number().nullable(),
+  after: z.number(),
+});
+
+export const ApiOrderAmendmentEntrySchema = z.object({
+  sequence: z.number(),
+  amended_at: z.string(),
+  changes: z.record(z.string(), ApiOrderAmendmentChangeSchema),
+  note: z.string().optional(),
+});
+
 export const ApiOrderRecordSchema = z.object({
   id: z.string(),
   onchain_id: z.number().nullable(),
@@ -22,6 +34,8 @@ export const ApiOrderRecordSchema = z.object({
   status: z.string(),
   counterparty: z.string().nullable(),
   created_at: z.string().nullable(),
+  amendment_count: z.number().default(0),
+  amendment_log: z.array(ApiOrderAmendmentEntrySchema).default([]),
 });
 
 export const ApiOrderListSchema = z.array(ApiOrderRecordSchema);

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -5,6 +5,18 @@ export interface ApiErrorShape {
   details?: unknown;
 }
 
+export interface ApiOrderAmendmentChange {
+  before: number | null;
+  after: number;
+}
+
+export interface ApiOrderAmendmentEntry {
+  sequence: number;
+  amended_at: string;
+  changes: Record<string, ApiOrderAmendmentChange>;
+  note?: string;
+}
+
 export interface ApiOrderRecord {
   id: string;
   onchain_id: number | null;
@@ -21,6 +33,16 @@ export interface ApiOrderRecord {
   status: string;
   counterparty: string | null;
   created_at: string | null;
+  amendment_count: number;
+  amendment_log: ApiOrderAmendmentEntry[];
+}
+
+export interface AmendOrderPayload {
+  from_amount?: number;
+  to_amount?: number;
+  min_fill_amount?: number;
+  expiry?: number;
+  note?: string;
 }
 
 export interface CreateOrderPayload {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -102,6 +102,18 @@ export enum OrderStatus {
   EXPIRED = "expired",
 }
 
+export interface OrderAmendmentChange {
+  before: number | null;
+  after: number;
+}
+
+export interface OrderAmendmentEntry {
+  sequence: number;
+  amended_at: string;
+  changes: Record<string, OrderAmendmentChange>;
+  note?: string;
+}
+
 export interface Order {
   id: string;
   maker: string;
@@ -121,6 +133,7 @@ export interface Order {
   expiresAt?: string;
   allowPartialFills?: boolean;
   amendmentCount?: number;
+  amendmentLog?: OrderAmendmentEntry[];
   minFillAmount?: string;
   makerFeeEstimate?: string;
   takerFeeEstimate?: string;
@@ -283,9 +296,11 @@ export interface ProtocolStats {
 }
 
 export type {
+  AmendOrderPayload,
   ApiErrorShape,
   ApiHTLCBaseRecord,
   ApiHTLCRecord,
+  ApiOrderAmendmentEntry,
   ApiOrderRecord,
   ApiSwapRecord,
   ClaimHTLCPayload,


### PR DESCRIPTION
closed #512 
feat(orders): add amendment history visibility (#512)

Persist amendment metadata on swap orders and expose it in the UI so
users can see how many times an order changed and what the latest state
is.

Backend:
- Add `amendment_count` (int) and `amendment_log` (JSONB) columns to
  `swap_orders` with migration 20260601_0005
- Add `PATCH /orders/{id}/amend` endpoint: validates the order is open,
  diffs changed fields (from_amount, to_amount, min_fill_amount, expiry),
  appends a structured log entry with sequence, amended_at, per-field
  before/after, and optional note, then increments amendment_count
- Extend `OrderResponse` with amendment_count and amendment_log
- Add `OrderAmend` and `OrderAmendmentEntry` Pydantic schemas
- Emit `order.updated` WebSocket event on every amendment
- Add tests: OrderAmend schema validation and amendment log accumulation

Frontend:
- Add `OrderAmendmentEntry` type and `amendmentLog` field to `Order`
- Extend `ApiOrderRecord` and Zod schema with amendment fields
- Add `amendOrder()` API helper (PATCH)
- List view: show amendment count badge on each card
- Detail card: show "Last amended" timestamp in Order Summary panel
- Expandable AmendmentHistory panel with per-entry sequence number,
  timestamp, field-level before→after diffs, note, and "Latest" badge
- Populate amendmentLog in mock seed data for amended orders

Closes #512
